### PR TITLE
Fix the grid block resize not working in the 7.1 editor

### DIFF
--- a/blocks/layout-grid/src/grid.scss
+++ b/blocks/layout-grid/src/grid.scss
@@ -46,6 +46,7 @@
 	@for $i from 1 through 12 {
 		@for $x from 1 through 4 {
 			&.column#{ $x }-grid__start-#{ $i } > .wpcom-resize-grid > .wp-block:nth-child(#{ $x }),
+			&.column#{ $x }-grid__start-#{ $i } > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block:nth-child(#{ $x }),
 			&.column#{ $x }-grid__start-#{ $i } > .block-editor-inner-blocks > .editor-block-list__layout > .wp-block:nth-child(#{ $x }) {
 				grid-column-start: $i;
 			}
@@ -55,6 +56,7 @@
 	@for $i from 1 through 12 {
 		@for $x from 1 through 4 {
 			&.column#{ $x }-grid__span-#{ $i } > .wpcom-resize-grid > .wp-block:nth-child(#{ $x }),
+			&.column#{ $x }-grid__span-#{ $i } > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block:nth-child(#{ $x }),
 			&.column#{ $x }-grid__span-#{ $i } > .block-editor-inner-blocks > .editor-block-list__layout > .wp-block:nth-child(#{ $x }) {
 				grid-column-end: span $i; // Set it to span $i columns, regardless of starting position.
 			}
@@ -68,6 +70,7 @@
 	@for $i from 1 through 4 {
 		@for $x from 1 through 4 {
 			&.column#{ $x }-grid__row-#{ $i } > .wpcom-resize-grid > .wp-block:nth-child(#{ $x }),
+			&.column#{ $x }-grid__row-#{ $i } > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block:nth-child(#{ $x }),
 			&.column#{ $x }-grid__row-#{ $i } > .block-editor-inner-blocks > .editor-block-list__layout > .wp-block:nth-child(#{ $x }) {
 				grid-row-start: $i;
 			}

--- a/blocks/layout-grid/src/grid.scss
+++ b/blocks/layout-grid/src/grid.scss
@@ -46,8 +46,7 @@
 	@for $i from 1 through 12 {
 		@for $x from 1 through 4 {
 			&.column#{ $x }-grid__start-#{ $i } > .wpcom-resize-grid > .wp-block:nth-child(#{ $x }),
-			&.column#{ $x }-grid__start-#{ $i } > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block:nth-child(#{ $x }),
-			&.column#{ $x }-grid__start-#{ $i } > .block-editor-inner-blocks > .editor-block-list__layout > .wp-block:nth-child(#{ $x }) {
+			&.column#{ $x }-grid__start-#{ $i } > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block:nth-child(#{ $x }) {
 				grid-column-start: $i;
 			}
 		}
@@ -56,8 +55,7 @@
 	@for $i from 1 through 12 {
 		@for $x from 1 through 4 {
 			&.column#{ $x }-grid__span-#{ $i } > .wpcom-resize-grid > .wp-block:nth-child(#{ $x }),
-			&.column#{ $x }-grid__span-#{ $i } > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block:nth-child(#{ $x }),
-			&.column#{ $x }-grid__span-#{ $i } > .block-editor-inner-blocks > .editor-block-list__layout > .wp-block:nth-child(#{ $x }) {
+			&.column#{ $x }-grid__span-#{ $i } > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block:nth-child(#{ $x }) {
 				grid-column-end: span $i; // Set it to span $i columns, regardless of starting position.
 			}
 		}
@@ -70,8 +68,7 @@
 	@for $i from 1 through 4 {
 		@for $x from 1 through 4 {
 			&.column#{ $x }-grid__row-#{ $i } > .wpcom-resize-grid > .wp-block:nth-child(#{ $x }),
-			&.column#{ $x }-grid__row-#{ $i } > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block:nth-child(#{ $x }),
-			&.column#{ $x }-grid__row-#{ $i } > .block-editor-inner-blocks > .editor-block-list__layout > .wp-block:nth-child(#{ $x }) {
+			&.column#{ $x }-grid__row-#{ $i } > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block:nth-child(#{ $x }) {
 				grid-row-start: $i;
 			}
 		}


### PR DESCRIPTION
A change in the inner blocks class name broke the CSS.

`editor-block-list__layout` => `block-editor-block-list__layout`

This supports both, so it should work on any version of Gutenberg.

I note that elsewhere we use `block-editor-block-list__layout`. Do we even need to support `editor-block-list__layout`?