### PR TITLE
Fix layout grid in 7.1 and specifically nested in groups.

### DIFF
--- a/blocks/layout-grid/editor.scss
+++ b/blocks/layout-grid/editor.scss
@@ -78,16 +78,6 @@
 			width: 100%;
 		}
 	}
-
-	&.is-selected > .block-editor-block-list__block-edit {
-		// When the block is selected, we scale it down to make room for the side UI.
-		width: calc( 100% + 44px + 44px );
-
-		// Make an exception for the group, which zeroes out a margin we need.
-		.wp-block-group & {
-			width: calc( 100% - 14px - 14px );
-		}
-	}
 }
 
 // Try hiding the alignments dropdown.

--- a/blocks/layout-grid/editor.scss
+++ b/blocks/layout-grid/editor.scss
@@ -67,8 +67,26 @@
 	align-items: center;
 
 	> .block-editor-block-list__block-edit {
-		width: calc( 100% + 44px + 44px ); // The 44px here come from the margin applied left and right of all blocks. @todo, consider a more upgrade friendly method.
 		transition: all .1s ease;
+
+		// The 58px here come from the padding applied to the body container.
+		// @todo, consider a more upgrade friendly method so this doesn't need to be aware of Gutenberg changes.
+		width: calc( 100% + 58px + 58px );
+
+		// Make an exception for the group, which zeroes out a margin we need.
+		.wp-block-group & {
+			width: 100%;
+		}
+	}
+
+	&.is-selected > .block-editor-block-list__block-edit {
+		// When the block is selected, we scale it down to make room for the side UI.
+		width: calc( 100% + 44px + 44px );
+
+		// Make an exception for the group, which zeroes out a margin we need.
+		.wp-block-group & {
+			width: calc( 100% - 14px - 14px );
+		}
 	}
 }
 

--- a/blocks/layout-grid/src/grid-resize.scss
+++ b/blocks/layout-grid/src/grid-resize.scss
@@ -65,17 +65,16 @@ body.is-resizing [data-type="jetpack/layout-grid"] {
 	overflow: inherit;
 }
 
+// When the block is selected, we scale it down to make room for the side UI.
 [data-type="jetpack/layout-grid"][data-align="full"].has-child-selected,
 [data-type="jetpack/layout-grid"][data-align="full"].is-selected,
 body.is-resizing [data-type="jetpack/layout-grid"][data-align="full"] {
 	> .block-editor-block-list__block-edit {
-		width: 100%;
-	}
+		width: calc( 100% + 30px + 30px + 8px ); // The 30 are from the canvas side padding (58px) minus the width of the side UI (28px).
 
-	// Show borders again
-	> .block-editor-block-list__block-edit::before {
-		border-left-width: 1px;
-		border-right-width: 1px;
-		border-style: solid;
+		// Make an exception for the group, which zeroes out a margin we need.
+		.wp-block-group & {
+			width: calc( 100% - 28px - 28px - 8px );
+		}
 	}
 }


### PR DESCRIPTION
Fixes #4.

This fix remains a bit hacky, and I'll make a note to self to ponder better solutions. But if this works well in older Gutenberg versions, it would be good to ship as an interim fix.