### PR TITLE
Remove Text Domain

### DIFF
--- a/bundler/template/index.php
+++ b/bundler/template/index.php
@@ -5,7 +5,6 @@
  * Version:     [VERSION]
  * Author:      Automattic
  * Author URI:  https://automattic.com
- * Text Domain: [RESOURCE]
  * License:     GPL v2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
  */


### PR DESCRIPTION
The Text Domain field isn't required, and if omitted will default to match the plugin slug.

https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains

closes #10