### PR TITLE
Set fixed width and height for button svg icons

### DIFF
--- a/blocks/bauhaus-centenary/editor.scss
+++ b/blocks/bauhaus-centenary/editor.scss
@@ -5,8 +5,10 @@
 	}
 
 	.components-icon-button svg {
-		height: 100%;
-		width: auto;
+		// IE11 requires a fixed width & height for SVGs. Values are calculated
+		// from what `height: 100%` and `width: auto` would have resulted in.
+		height: 26px;
+		width: 39px;
 	}
 }
 


### PR DESCRIPTION
IE requires a fixed with and height for SVGs or they won't scale up at
all making the buttons unreadable in IE.