### PR TITLE
Fix grid block

### DIFF
--- a/blocks/layout-grid/editor.scss
+++ b/blocks/layout-grid/editor.scss
@@ -16,6 +16,10 @@
 	margin-bottom: 0;
 }
 
+[data-type="jetpack/layout-grid"] > div {
+	width: 100%;
+}
+
 [data-type="jetpack/layout-grid-column"].wp-block { // Selector needs specificity to override.
 	// 2. Unset margins and paddings for column container.
 	padding-left: 0;
@@ -39,6 +43,7 @@
 
 [data-type="jetpack/layout-grid"] {
 	// Pending refinements, hide the v6.3 dashed outlines on grid children, they aren't helpful here.
+	// @todo Revisit/remove for 5.4.
 	.block-editor-block-list__block:not(.is-selected) > .block-editor-block-list__block-edit::before {
 		border-color: transparent !important;
 	}
@@ -89,7 +94,7 @@
 // Hide the hover style & breadcrumbs for individual column containers.
 // This helps simplify the experience for resizing columns.
 // The hover effect may be removed entirely upstream, in which case we can remove this.
-// Ticket to watch: https://github.com/WordPress/gutenberg/issues/17088
+// @todo Revisit/remove for 5.4.
 [data-type="jetpack/layout-grid-column"].is-hovered > .block-editor-block-list__block-edit {
 	// Don't show breadcrumbs.
 	> .block-editor-block-list__breadcrumb {
@@ -148,13 +153,15 @@
 	flex-wrap: nowrap;
 	width: 100%;
 	list-style: none;
+	margin-left: 0;
 	margin-bottom: 0;
+	padding-left: 0;
 
 	> li {
 		list-style: none;
-		flex-basis: 100%;
 		flex-shrink: 1;
 		max-width: 100px;
+		margin-right: 8px;
 	}
 
 	.block-editor-inner-blocks__template-picker-option {

--- a/blocks/layout-grid/editor.scss
+++ b/blocks/layout-grid/editor.scss
@@ -161,11 +161,12 @@
 	margin-bottom: 0;
 	padding-left: 0;
 
-	> li {
+	> li .components-button {
 		list-style: none;
 		flex-shrink: 1;
-		max-width: 100px;
+		max-width: 72px;
 		margin-right: 8px;
+		flex-basis: 100%;
 	}
 
 	.block-editor-inner-blocks__template-picker-option {

--- a/blocks/layout-grid/editor.scss
+++ b/blocks/layout-grid/editor.scss
@@ -16,10 +16,6 @@
 	margin-bottom: 0;
 }
 
-[data-type="jetpack/layout-grid"] > div {
-	width: 100%;
-}
-
 [data-type="jetpack/layout-grid-column"].wp-block { // Selector needs specificity to override.
 	// 2. Unset margins and paddings for column container.
 	padding-left: 0;
@@ -71,6 +67,15 @@
 	flex-direction: column;
 	align-items: center;
 
+	// Fit available space.
+	// This rule is for newer versions of the plugin and WordPress 5.4.
+	> div {
+		width: 100%;
+		transition: all .1s ease;
+	}
+
+	// This rule is for older versions of the plugin and WordPress 5.3.
+	// @todo Revisit/remove for 5.4.
 	> .block-editor-block-list__block-edit {
 		transition: all .1s ease;
 

--- a/blocks/layout-grid/editor.scss
+++ b/blocks/layout-grid/editor.scss
@@ -71,7 +71,7 @@
 	// This rule is for newer versions of the plugin and WordPress 5.4.
 	> div {
 		width: 100%;
-		transition: all .1s ease;
+		transition: all .05s ease;
 	}
 
 	// This rule is for older versions of the plugin and WordPress 5.3.

--- a/blocks/layout-grid/editor.scss
+++ b/blocks/layout-grid/editor.scss
@@ -18,12 +18,12 @@
 
 [data-type="jetpack/layout-grid-column"].wp-block { // Selector needs specificity to override.
 	// 2. Unset margins and paddings for column container.
+	margin: 0;
 	padding-left: 0;
-	margin-left: 0;
 	padding-right: 0;
-	margin-right: 0;
 
 	// 3. Unset for contents of container.
+	// @todo Revisit/remove for 5.4.
 	> .block-editor-block-list__block-edit {
 		padding-left: 0;
 		margin-left: 0;

--- a/blocks/layout-grid/editor.scss
+++ b/blocks/layout-grid/editor.scss
@@ -71,7 +71,6 @@
 	// This rule is for newer versions of the plugin and WordPress 5.4.
 	> div {
 		width: 100%;
-		transition: all .05s ease;
 	}
 
 	// This rule is for older versions of the plugin and WordPress 5.3.

--- a/blocks/layout-grid/src/grid-overlay.scss
+++ b/blocks/layout-grid/src/grid-overlay.scss
@@ -31,7 +31,7 @@
 
 	// Lower the z-index so it's under the block borders.
 	// @todo: Verify this doesn't mess with alternate templates and background styles.
-	z-index: -1;
+	z-index: 0;
 
 	.wpcom-overlay-grid__column {
 		border-left: 1px solid transparent;

--- a/blocks/layout-grid/src/grid-resize.scss
+++ b/blocks/layout-grid/src/grid-resize.scss
@@ -86,6 +86,11 @@ body.is-resizing [data-type="jetpack/layout-grid"][data-align="full"] {
 	&::before {
 		border-right-width: 1px;
 	}
+
+	// @todo Remove for 5.4, as it won't be necessary.
+	.block-editor-block-list__block-edit::before {
+		border-right-width: 1px;
+	}
 }
 
 // This rule is for older versions of the plugin and WordPress 5.3.

--- a/blocks/layout-grid/src/grid-resize.scss
+++ b/blocks/layout-grid/src/grid-resize.scss
@@ -79,8 +79,12 @@ body.is-resizing [data-type="jetpack/layout-grid"] {
 [data-type="jetpack/layout-grid"][data-align="full"].has-child-selected,
 [data-type="jetpack/layout-grid"][data-align="full"].is-selected,
 body.is-resizing [data-type="jetpack/layout-grid"][data-align="full"] {
-	> div {
-		width: calc( 100% - 28px - 28px - 8px );
+	width: 100%;
+	margin-left: auto;
+	margin-right: auto;
+
+	&::before {
+		border-right-width: 1px;
 	}
 }
 

--- a/blocks/layout-grid/src/grid-resize.scss
+++ b/blocks/layout-grid/src/grid-resize.scss
@@ -65,7 +65,26 @@ body.is-resizing [data-type="jetpack/layout-grid"] {
 	overflow: inherit;
 }
 
+
+/**
+ * Scale down the Grid Block when Selected.
+ */
+
+
 // When the block is selected, we scale it down to make room for the side UI.
+// This becomes unnecessary with https://github.com/WordPress/gutenberg/pull/19344.
+// @todo Revisit/remove for 5.4.
+
+// This rule is for newer versions of the plugin and WordPress 5.4.
+[data-type="jetpack/layout-grid"][data-align="full"].has-child-selected,
+[data-type="jetpack/layout-grid"][data-align="full"].is-selected,
+body.is-resizing [data-type="jetpack/layout-grid"][data-align="full"] {
+	> div {
+		width: calc( 100% - 28px - 28px - 8px );
+	}
+}
+
+// This rule is for older versions of the plugin and WordPress 5.3.
 [data-type="jetpack/layout-grid"][data-align="full"].has-child-selected,
 [data-type="jetpack/layout-grid"][data-align="full"].is-selected,
 body.is-resizing [data-type="jetpack/layout-grid"][data-align="full"] {

--- a/blocks/layout-grid/src/grid.scss
+++ b/blocks/layout-grid/src/grid.scss
@@ -127,16 +127,18 @@
 }
 
 [data-type="jetpack/layout-grid"].is-selected .wp-block-jetpack-layout-resizable .wp-blocks-jetpack-layout-grid__resize-handles .components-resizable-box__handle,
-[data-type="jetpack/layout-grid"] .wp-block-jetpack-layout-resizable [data-type="jetpack/layout-grid-column"].is-selected .wp-blocks-jetpack-layout-grid__resize-handles .components-resizable-box__handle {
+[data-type="jetpack/layout-grid"] [data-type="jetpack/layout-grid-column"].is-selected .wp-blocks-jetpack-layout-grid__resize-handles .components-resizable-box__handle {
 	display: block;
 }
 
 // These colors are copied from upstream Gutenberg to ensure opacities when the theme is dark.
+// @todo Revisit/remove for 5.4.
 $dark-opacity-light-800: rgba(#425863, 0.4);
 $light-opacity-light-800: rgba(#fff, 0.45);
 
 // Show a special style of block borders for the individual columns, so they line up with the drag handle.
-[data-type="jetpack/layout-grid-column"].is-selected > .block-editor-block-list__block-edit.block-editor-block-list__block-edit { // Increase specificity.
+[data-type="jetpack/layout-grid-column"].is-selected.is-selected, // This rule is for newer versions of the plugin and WordPress 5.3. Extra specificity can be removed when G2 UI lands.
+[data-type="jetpack/layout-grid-column"].is-selected > .block-editor-block-list__block-edit.block-editor-block-list__block-edit { // This rule is for older versions of the plugin and WordPress 5.3.
 	> .block-editor-block-contextual-toolbar > .block-editor-block-toolbar {
 		left: 18px;
 	}

--- a/blocks/layout-grid/src/grid.scss
+++ b/blocks/layout-grid/src/grid.scss
@@ -148,10 +148,14 @@ $light-opacity-light-800: rgba(#fff, 0.45);
 		left: 0;
 		right: 0;
 
+		border-color:  $dark-opacity-light-800;
 		border-left: 1px dashed $dark-opacity-light-800;
 		border-style: dashed;
+		border-width: 1px;
+
 		// Use opacity to work in various editor styles
 		.is-dark-theme & {
+			border-color:  $light-opacity-light-800;
 			border-left: 1px dashed $light-opacity-light-800;
 		}
 	}

--- a/blocks/layout-grid/src/grid/edit.js
+++ b/blocks/layout-grid/src/grid/edit.js
@@ -195,7 +195,7 @@ class Edit extends Component {
 						{ getColumns().map( ( column ) => (
 							<li key={ column.value }>
 								<IconButton
-									isLarge
+									isSecondary
 									icon={ <ColumnIcon columns={ column.value } /> }
 									onClick={ () => this.onChangeLayout( column.value ) }
 									className="block-editor-inner-blocks__template-picker-option"

--- a/blocks/layout-grid/src/grid/edit.js
+++ b/blocks/layout-grid/src/grid/edit.js
@@ -14,7 +14,7 @@ import {
 	InspectorControls,
 } from '@wordpress/block-editor';
 import { Component, createRef } from '@wordpress/element';
-import { PanelBody, TextControl, ButtonGroup, Button, Placeholder, IsolatedEventContainer } from '@wordpress/components';
+import { PanelBody, TextControl, ButtonGroup, Button, IconButton, Placeholder, IsolatedEventContainer } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -194,7 +194,7 @@ class Edit extends Component {
 					<ul className="block-editor-inner-blocks__template-picker-options">
 						{ getColumns().map( ( column ) => (
 							<li key={ column.value }>
-								<Button
+								<IconButton
 									isSecondary
 									icon={ <ColumnIcon columns={ column.value } /> }
 									onClick={ () => this.onChangeLayout( column.value ) }

--- a/blocks/layout-grid/src/grid/edit.js
+++ b/blocks/layout-grid/src/grid/edit.js
@@ -14,7 +14,7 @@ import {
 	InspectorControls,
 } from '@wordpress/block-editor';
 import { Component, createRef } from '@wordpress/element';
-import { PanelBody, TextControl, ButtonGroup, Button, Placeholder, IconButton, IsolatedEventContainer } from '@wordpress/components';
+import { PanelBody, TextControl, ButtonGroup, Button, Placeholder, IsolatedEventContainer } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -194,7 +194,7 @@ class Edit extends Component {
 					<ul className="block-editor-inner-blocks__template-picker-options">
 						{ getColumns().map( ( column ) => (
 							<li key={ column.value }>
-								<IconButton
+								<Button
 									isSecondary
 									icon={ <ColumnIcon columns={ column.value } /> }
 									onClick={ () => this.onChangeLayout( column.value ) }


### PR DESCRIPTION
In recent releases of the plugin, the Grid block has broken in a few ways:

- The placeholder is no longer full width in latest plugin
- The placeholder looks off
- The overlay disappeared

This PR fixes all that.

There's some back compat CSS kept here, but with comments now. It fixes this:

- Placeholder is full width
- Overlay grid is visible again
- Individual columns can be resized.

Before:

<img width="1313" alt="Screenshot 2020-01-20 at 11 37 54" src="https://user-images.githubusercontent.com/1204802/72724123-bf549480-3b82-11ea-902f-98f5dd29e19d.png">

After:

<img width="1322" alt="Screenshot 2020-01-20 at 11 38 01" src="https://user-images.githubusercontent.com/1204802/72724144-ca0f2980-3b82-11ea-920c-4e5e2ad2edcc.png">

<img width="1111" alt="Screenshot 2020-01-20 at 11 31 29" src="https://user-images.githubusercontent.com/1204802/72724150-d0050a80-3b82-11ea-8040-d1f90c89f001.png">

<img width="1159" alt="Screenshot 2020-01-20 at 12 46 03" src="https://user-images.githubusercontent.com/1204802/72724155-d6938200-3b82-11ea-991e-236e39006969.png">
