### PR TITLE
Polish grid further

### DIFF
--- a/blocks/layout-grid/editor.scss
+++ b/blocks/layout-grid/editor.scss
@@ -161,6 +161,12 @@
 	margin-bottom: 0;
 	padding-left: 0;
 
+	li {
+		margin-left: 0;
+		padding-left: 0;
+		list-style: none;
+	}
+
 	> li .components-button {
 		list-style: none;
 		flex-shrink: 1;

--- a/blocks/layout-grid/src/grid-overlay.scss
+++ b/blocks/layout-grid/src/grid-overlay.scss
@@ -13,7 +13,8 @@
 	// constantly "refresh" this hack.
 	position: relative;
 	.is-hovered &,
-	.is-selected & {
+	.is-selected &,
+	.has-child-selected & {
 		position: absolute;
 	}
 

--- a/blocks/layout-grid/src/grid-resize.scss
+++ b/blocks/layout-grid/src/grid-resize.scss
@@ -31,7 +31,7 @@
 
 	// Every block, including nested blocks, are born with an intrinsic minimum margin.
 	// This resets that for the containers, which aren't meant to have that intrinsically.
-	> .wp-block > .editor-block-list__block-edit > [data-block] {
+	> .wp-block > .block-editor-block-list__block-edit > [data-block] {
 		margin-top: 0;
 		margin-bottom: 0;
 	}

--- a/blocks/layout-grid/src/grid.scss
+++ b/blocks/layout-grid/src/grid.scss
@@ -18,7 +18,7 @@
 
 	// Every block, including nested blocks, are born with an intrinsic minimum margin.
 	// This resets that for the containers, which aren't meant to have that intrinsically.
-	> .wp-block > .editor-block-list__block-edit > [data-block] {
+	> .wp-block > .block-editor-block-list__block-edit > [data-block] {
 		margin-top: 0;
 		margin-bottom: 0;
 	}
@@ -161,7 +161,7 @@ $light-opacity-light-800: rgba(#fff, 0.45);
 	}
 }
 
-/* When clicked, hide the fake drag handles and show the real one */
+// When clicked, hide the fake drag handles and show the real one.
 .wp-block-jetpack-layout-grid__resizing {
 	user-select: none;
 	z-index: 10000;

--- a/blocks/layout-grid/src/grid.scss
+++ b/blocks/layout-grid/src/grid.scss
@@ -127,7 +127,7 @@
 }
 
 [data-type="jetpack/layout-grid"].is-selected .wp-block-jetpack-layout-resizable .wp-blocks-jetpack-layout-grid__resize-handles .components-resizable-box__handle,
-[data-type="jetpack/layout-grid"] [data-type="jetpack/layout-grid-column"].is-selected .wp-blocks-jetpack-layout-grid__resize-handles .components-resizable-box__handle {
+[data-type="jetpack/layout-grid"] .wp-block-jetpack-layout-resizable [data-type="jetpack/layout-grid-column"].is-selected .wp-blocks-jetpack-layout-grid__resize-handles .components-resizable-box__handle {
 	display: block;
 }
 


### PR DESCRIPTION
Alright, this fixes the two issues uncovered yesterday, plus another one:

- Margins were too wide
- Resize handles were visible on column(s) when they shouldn't be
- Also, just discovered, the grid wasn't visible when resizing column(s)

