### PR TITLE
Layout grid: fix long lines not wrapping

### DIFF
--- a/blocks/layout-grid/front.css
+++ b/blocks/layout-grid/front.css
@@ -687,3 +687,6 @@
         grid-row-start: 4; }
       .wp-block-jetpack-layout-grid.column4-desktop-grid__row-4 > .wp-block-jetpack-layout-grid-column:nth-child(4) {
         grid-row-start: 4; } }
+  .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column * {
+    word-break: break-word;
+    word-wrap: break-word; }

--- a/blocks/layout-grid/front.scss
+++ b/blocks/layout-grid/front.scss
@@ -100,4 +100,10 @@
 			}
 		}
 	}
+
+	// Ensure long lines wrap in themes that don't already enforce this
+	.wp-block-jetpack-layout-grid-column * {
+		word-break: break-word;
+		word-wrap: break-word;
+	}
 }


### PR DESCRIPTION
Long words on themes without specific long word wrapping CSS can break out of the layout grid.

![Layout Grid Test](https://user-images.githubusercontent.com/16104522/74033861-d0304300-4995-11ea-8dd8-d77f5acd50e9.png)

This adds a specific word wrap to grid columns to make sure a long word doesn’t break out.
