### PR TITLE
Add a ‘remove end gutters’ option

### DIFF
--- a/blocks/layout-grid/src/grid-overlay.scss
+++ b/blocks/layout-grid/src/grid-overlay.scss
@@ -48,6 +48,10 @@
 	}
 }
 
+.wp-block-jetpack-layout-grid__nowrap .wpcom-overlay-grid {
+	padding-left: 0;
+	padding-right: 0;
+}
 
 body.is-resizing .wpcom-overlay-grid .wpcom-overlay-grid__column {
 	border-left: 1px solid #e2e4e7;

--- a/blocks/layout-grid/src/grid-overlay.scss
+++ b/blocks/layout-grid/src/grid-overlay.scss
@@ -48,7 +48,7 @@
 	}
 }
 
-.wp-block-jetpack-layout-grid__nowrap .wpcom-overlay-grid {
+.wp-block-jetpack-layout-gutter__nowrap .wpcom-overlay-grid {
 	padding-left: 0;
 	padding-right: 0;
 }

--- a/blocks/layout-grid/src/grid/css-classname.js
+++ b/blocks/layout-grid/src/grid/css-classname.js
@@ -125,7 +125,7 @@ export function getAsCSS( columns, attributes = {} ) {
 	}
 
 	if ( ! attributes.addGutterEnds ) {
-		classes[ 'wp-block-jetpack-layout-grid__nowrap' ] = true;
+		classes[ 'wp-block-jetpack-layout-gutter__nowrap' ] = true;
 	}
 
 	return classes;
@@ -140,5 +140,17 @@ export function removeGridClasses( classes ) {
 		.replace( /column\d-\w*-grid__\w*-\d*/g, '' )
 		.replace( /column\d-grid__\w*-\d*/g, '' )
 		.replace( /\s{2,}/, '' )
-		.replace( 'wp-block-jetpack-layout-grid__nowrap', '' );
+		.replace( /wp-block-jetpack-layout-gutter__\w*/, '' );
+}
+
+export function getGutterClasses( { gutterSize, addGutterEnds } ) {
+	console.log( addGutterEnds );
+	return {
+		'wp-block-jetpack-layout-gutter__nowrap': ! addGutterEnds,
+		'wp-block-jetpack-layout-gutter__none': gutterSize === 'none',
+		'wp-block-jetpack-layout-gutter__small': gutterSize === 'small',
+		'wp-block-jetpack-layout-gutter__medium': gutterSize === 'medium',
+		'wp-block-jetpack-layout-gutter__large': gutterSize === 'large',
+		'wp-block-jetpack-layout-gutter__huge': gutterSize === 'huge',
+	};
 }

--- a/blocks/layout-grid/src/grid/css-classname.js
+++ b/blocks/layout-grid/src/grid/css-classname.js
@@ -124,7 +124,7 @@ export function getAsCSS( columns, attributes = {} ) {
 		};
 	}
 
-	if ( attributes.removeGutterWrap ) {
+	if ( ! attributes.addGutterEnds ) {
 		classes[ 'wp-block-jetpack-layout-grid__nowrap' ] = true;
 	}
 
@@ -139,5 +139,6 @@ export function removeGridClasses( classes ) {
 	return classes
 		.replace( /column\d-\w*-grid__\w*-\d*/g, '' )
 		.replace( /column\d-grid__\w*-\d*/g, '' )
-		.replace( /\s{2,}/, '' );
+		.replace( /\s{2,}/, '' )
+		.replace( 'wp-block-jetpack-layout-grid__nowrap', '' );
 }

--- a/blocks/layout-grid/src/grid/css-classname.js
+++ b/blocks/layout-grid/src/grid/css-classname.js
@@ -124,6 +124,10 @@ export function getAsCSS( columns, attributes = {} ) {
 		};
 	}
 
+	if ( attributes.removeGutterWrap ) {
+		classes[ 'wp-block-jetpack-layout-grid__nowrap' ] = true;
+	}
+
 	return classes;
 }
 

--- a/blocks/layout-grid/src/grid/edit.js
+++ b/blocks/layout-grid/src/grid/edit.js
@@ -14,7 +14,17 @@ import {
 	InspectorControls,
 } from '@wordpress/block-editor';
 import { Component, createRef } from '@wordpress/element';
-import { PanelBody, TextControl, ButtonGroup, Button, IconButton, Placeholder, IsolatedEventContainer } from '@wordpress/components';
+import {
+	PanelBody,
+	TextControl,
+	ButtonGroup,
+	Button,
+	IconButton,
+	Placeholder,
+	IsolatedEventContainer,
+	SelectControl,
+	CheckboxControl,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -168,9 +178,11 @@ class Edit extends Component {
 			attributes = {},
 			isSelected,
 			columns,
+			setAttributes,
 		} = this.props;
 		const { selectedDevice } = this.state;
 		const extra = getAsDeviceCSS( selectedDevice, columns, attributes );
+		const { removeGutterWrap } = attributes;
 		const layoutGrid = new LayoutGrid( attributes, selectedDevice, columns );
 		const classes = classnames(
 			removeGridClasses( className ),
@@ -180,6 +192,7 @@ class Edit extends Component {
 				'wp-block-jetpack-layout-desktop': selectedDevice === 'Desktop',
 				'wp-block-jetpack-layout-mobile': selectedDevice === 'Mobile',
 				'wp-block-jetpack-layout-resizable': this.canResizeBreakpoint( selectedDevice ),
+				'wp-block-jetpack-layout-grid__nowrap': removeGutterWrap,
 			}
 		);
 
@@ -278,6 +291,15 @@ class Edit extends Component {
 							</ButtonGroup>
 
 							{ this.renderDeviceSettings( columns, selectedDevice, attributes ) }
+						</PanelBody>
+
+						<PanelBody title={ __( 'Gutter' ) }>
+							<CheckboxControl
+								label={ __( 'Remove end gutters' ) }
+								help={ __( 'Remove gutters at start and end of the grid' ) }
+								checked={ removeGutterWrap }
+								onChange={ newValue => setAttributes( { removeGutterWrap: newValue } )  }
+							/>
 						</PanelBody>
 					</InspectorControls>
 

--- a/blocks/layout-grid/src/grid/edit.js
+++ b/blocks/layout-grid/src/grid/edit.js
@@ -22,8 +22,7 @@ import {
 	IconButton,
 	Placeholder,
 	IsolatedEventContainer,
-	SelectControl,
-	CheckboxControl,
+	ToggleControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { ENTER, SPACE } from '@wordpress/keycodes';
@@ -182,7 +181,7 @@ class Edit extends Component {
 		} = this.props;
 		const { selectedDevice } = this.state;
 		const extra = getAsDeviceCSS( selectedDevice, columns, attributes );
-		const { removeGutterWrap } = attributes;
+		const { addGutterEnds } = attributes;
 		const layoutGrid = new LayoutGrid( attributes, selectedDevice, columns );
 		const classes = classnames(
 			removeGridClasses( className ),
@@ -192,7 +191,7 @@ class Edit extends Component {
 				'wp-block-jetpack-layout-desktop': selectedDevice === 'Desktop',
 				'wp-block-jetpack-layout-mobile': selectedDevice === 'Mobile',
 				'wp-block-jetpack-layout-resizable': this.canResizeBreakpoint( selectedDevice ),
-				'wp-block-jetpack-layout-grid__nowrap': removeGutterWrap,
+				'wp-block-jetpack-layout-grid__nowrap': ! addGutterEnds,
 			}
 		);
 
@@ -294,11 +293,11 @@ class Edit extends Component {
 						</PanelBody>
 
 						<PanelBody title={ __( 'Gutter' ) }>
-							<CheckboxControl
-								label={ __( 'Remove end gutters' ) }
-								help={ __( 'Remove gutters at start and end of the grid' ) }
-								checked={ removeGutterWrap }
-								onChange={ newValue => setAttributes( { removeGutterWrap: newValue } )  }
+							<ToggleControl
+								label={ __( 'Add end gutters' ) }
+								help={ __( 'Toggle to remove the spacing left and right of the grid.' ) }
+								checked={ addGutterEnds }
+								onChange={ newValue => setAttributes( { addGutterEnds: newValue } )  }
 							/>
 						</PanelBody>
 					</InspectorControls>

--- a/blocks/layout-grid/src/grid/edit.js
+++ b/blocks/layout-grid/src/grid/edit.js
@@ -34,7 +34,7 @@ import { createBlock } from '@wordpress/blocks';
  * Internal dependencies
  */
 
-import { getAsDeviceCSS, removeGridClasses } from './css-classname';
+import { getAsDeviceCSS, removeGridClasses, getGutterClasses } from './css-classname';
 import ColumnIcon from '../icons';
 import { getLayouts, getColumns, DEVICE_BREAKPOINTS, getSpanForDevice, getOffsetForDevice } from '../constants';
 import { getGridWidth, getDefaultSpan } from './grid-defaults';
@@ -191,8 +191,8 @@ class Edit extends Component {
 				'wp-block-jetpack-layout-desktop': selectedDevice === 'Desktop',
 				'wp-block-jetpack-layout-mobile': selectedDevice === 'Mobile',
 				'wp-block-jetpack-layout-resizable': this.canResizeBreakpoint( selectedDevice ),
-				'wp-block-jetpack-layout-grid__nowrap': ! addGutterEnds,
-			}
+			},
+			getGutterClasses( attributes ),
 		);
 
 		if ( columns === 0 ) {
@@ -295,7 +295,9 @@ class Edit extends Component {
 						<PanelBody title={ __( 'Gutter' ) }>
 							<ToggleControl
 								label={ __( 'Add end gutters' ) }
-								help={ __( 'Toggle to remove the spacing left and right of the grid.' ) }
+								help={
+									addGutterEnds ? __( 'Toggle off to remove the spacing left and right of the grid.' ) : __( 'Toggle on to add space left and right of the layout grid. ' )
+								}
 								checked={ addGutterEnds }
 								onChange={ newValue => setAttributes( { addGutterEnds: newValue } )  }
 							/>

--- a/blocks/layout-grid/src/grid/save.js
+++ b/blocks/layout-grid/src/grid/save.js
@@ -14,14 +14,18 @@ import { InnerBlocks } from '@wordpress/block-editor';
  * Internal dependencies
  */
 
-import { getAsCSS, removeGridClasses } from './css-classname';
+import { getAsCSS, removeGridClasses, getGutterClasses } from './css-classname';
 
 const save = ( { attributes, innerBlocks } ) => {
 	const {
 		className,
 	} = attributes;
 	const extra = getAsCSS( innerBlocks.length, attributes );
-	const classes = classnames( removeGridClasses( className ), extra );
+	const classes = classnames(
+		removeGridClasses( className ),
+		extra,
+		getGutterClasses( attributes ),
+	);
 
 	return (
 		<div className={ classes }>

--- a/blocks/layout-grid/src/index.js
+++ b/blocks/layout-grid/src/index.js
@@ -75,9 +75,9 @@ export function registerBlock() {
 				type: 'string',
 				default: 'full',
 			},
-			removeGutterWrap: {
+			addGutterEnds: {
 				type: 'boolean',
-				default: false,
+				default: true,
 			},
 			...getColumnAttributes( MAX_COLUMNS, DEVICE_BREAKPOINTS ),
 		},

--- a/blocks/layout-grid/src/index.js
+++ b/blocks/layout-grid/src/index.js
@@ -75,6 +75,10 @@ export function registerBlock() {
 				type: 'string',
 				default: 'full',
 			},
+			removeGutterWrap: {
+				type: 'boolean',
+				default: false,
+			},
 			...getColumnAttributes( MAX_COLUMNS, DEVICE_BREAKPOINTS ),
 		},
 		edit: editGrid,

--- a/blocks/layout-grid/style.scss
+++ b/blocks/layout-grid/style.scss
@@ -14,7 +14,7 @@
 	padding-left: 24px;
 	padding-right: 24px;
 
-	&.wp-block-jetpack-layout-grid__nowrap {
+	&.wp-block-jetpack-layout-gutter__nowrap {
 		padding-left: 0;
 		padding-right: 0;
 	}

--- a/blocks/layout-grid/style.scss
+++ b/blocks/layout-grid/style.scss
@@ -14,6 +14,11 @@
 	padding-left: 24px;
 	padding-right: 24px;
 
+	&.wp-block-jetpack-layout-grid__nowrap {
+		padding-left: 0;
+		padding-right: 0;
+	}
+
 	// Additional, user-set paddings.
 	// Apply both gutter padding and user-set padding, when a background is also set.
 	&.wp-block-jetpack-layout-grid__padding-none {
@@ -56,6 +61,7 @@
 		}
 	}
 }
+
 
 /**
  * Individual Column Options


### PR DESCRIPTION
This adds an option to remove the end gutters from the layout grid. The option is available in the parent grid:

![Edit_Post_‹_Latest_—_WordPress](https://user-images.githubusercontent.com/1277682/75871059-e352f900-5e03-11ea-8596-19767f6e3440.jpg)

Enabling the option removes gutters in the editor.

Before:

![Edit_Post_‹_Latest_—_WordPress](https://user-images.githubusercontent.com/1277682/75871152-05e51200-5e04-11ea-801d-0fe7b6d541e2.jpg)

After:

![Edit_Post_‹_Latest_—_WordPress](https://user-images.githubusercontent.com/1277682/75871220-2319e080-5e04-11ea-8591-c436ff88c2cc.jpg)

The same applies to the front end.

Fixes #29 