### PR TITLE
Add configurable gutter sizes to layout grid

### DIFF
--- a/blocks/layout-grid/constants.scss
+++ b/blocks/layout-grid/constants.scss
@@ -4,6 +4,11 @@ $grid-tablet: repeat(8, 1fr);
 $grid-mobile: repeat(4, 1fr);
 
 $grid-gutter: 24px;
+$grid-gutter-none: 0px;
+$grid-gutter-small: 8px;
+$grid-gutter-medium: 16px;
+$grid-gutter-large: $grid-gutter;
+$grid-gutter-huge: 48px;
 $grid-gutter__background-offset: $grid-gutter / 2 + 1px;
 $padding-none: 0px;
 $padding-small: 8px;

--- a/blocks/layout-grid/front.css
+++ b/blocks/layout-grid/front.css
@@ -1032,6 +1032,16 @@
     word-break: break-word;
     word-wrap: break-word; }
 
+  .wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__none {
+    grid-gap: 0px; }
+  .wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__small {
+    grid-gap: 8px; }
+  .wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__medium {
+    grid-gap: 16px; }
+  .wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__huge {
+    grid-gap: 48px; }
+
 @-moz-document url-prefix() {
   .wp-block-jetpack-layout-grid .wp-block-cover {
     max-height: 0; } }
+

--- a/blocks/layout-grid/front.scss
+++ b/blocks/layout-grid/front.scss
@@ -108,6 +108,22 @@
 		word-wrap: break-word;
 	}
 
+	&.wp-block-jetpack-layout-gutter__none {
+		grid-gap: $grid-gutter-none;
+	}
+
+	&.wp-block-jetpack-layout-gutter__small {
+		grid-gap: $grid-gutter-small;
+	}
+
+	&.wp-block-jetpack-layout-gutter__medium {
+		grid-gap: $grid-gutter-medium;
+	}
+
+	&.wp-block-jetpack-layout-gutter__huge {
+		grid-gap: $grid-gutter-huge;
+	}
+
 	// Fixes an issue in Firefox where a block in the grid with 100% height causes the grid to increase in height
 	@-moz-document url-prefix() {
 		.wp-block-cover {

--- a/blocks/layout-grid/src/constants.js
+++ b/blocks/layout-grid/src/constants.js
@@ -4,13 +4,22 @@
 
 import { __ } from '@wordpress/i18n';
 
+function getSpacingValues() {
+	return [
+		{ value: 'small', label: __( 'Small', 'layout-grid' ) },
+		{ value: 'medium', label: __( 'Medium', 'layout-grid' ) },
+		{ value: 'large', label: __( 'Large', 'layout-grid' ) },
+		{ value: 'huge', label: __( 'Huge', 'layout-grid' ) },
+	];
+}
+
 export const getPaddingValues = () => (	[
 	{ value: 'none', label: __( 'No padding', 'layout-grid' ) },
-	{ value: 'small', label: __( 'Small', 'layout-grid' ) },
-	{ value: 'medium', label: __( 'Medium', 'layout-grid' ) },
-	{ value: 'large', label: __( 'Large', 'layout-grid' ) },
-	{ value: 'huge', label: __( 'Huge', 'layout-grid' ) },
-] );
+].concat( getSpacingValues() ) );
+
+export const getGutterValues = () => ( [
+	{ value: 'none', label: __( 'No gutter', 'layout-grid' ) },
+].concat( getSpacingValues() ) );
 
 export const getColumns = () => ( [
 	{

--- a/blocks/layout-grid/src/grid-overlay.scss
+++ b/blocks/layout-grid/src/grid-overlay.scss
@@ -48,9 +48,33 @@
 	}
 }
 
+.wp-block-jetpack-layout-gutter__none .wpcom-overlay-grid {
+	grid-gap: $grid-gutter-none;
+	padding-left: $padding-none;
+	padding-right: $padding-none;
+}
+
+.wp-block-jetpack-layout-gutter__small .wpcom-overlay-grid {
+	grid-gap: $grid-gutter-small;
+	padding-left: $padding-small;
+	padding-right: $padding-small;
+}
+
+.wp-block-jetpack-layout-gutter__medium .wpcom-overlay-grid {
+	grid-gap: $grid-gutter-medium;
+	padding-left: $padding-medium;
+	padding-right: $padding-medium;
+}
+
+.wp-block-jetpack-layout-gutter__huge .wpcom-overlay-grid {
+	grid-gap: $grid-gutter-huge;
+	padding-left: $padding-huge;
+	padding-right: $padding-huge;
+}
+
 .wp-block-jetpack-layout-gutter__nowrap .wpcom-overlay-grid {
-	padding-left: 0;
-	padding-right: 0;
+	padding-left: $padding-none;
+	padding-right: $padding-none;
 }
 
 body.is-resizing .wpcom-overlay-grid .wpcom-overlay-grid__column {

--- a/blocks/layout-grid/src/grid-resize.scss
+++ b/blocks/layout-grid/src/grid-resize.scss
@@ -46,6 +46,22 @@
 	}
 }
 
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__none .wpcom-resize-grid:not(.wpcom-resize-grid__resizing) {
+	grid-gap: $grid-gutter-none;
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__small .wpcom-resize-grid:not(.wpcom-resize-grid__resizing) {
+	grid-gap: $grid-gutter-small;
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__medium .wpcom-resize-grid:not(.wpcom-resize-grid__resizing) {
+	grid-gap: $grid-gutter-medium;
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__huge .wpcom-resize-grid:not(.wpcom-resize-grid__resizing) {
+	grid-gap: $grid-gutter-huge;
+}
+
 .wpcom-resize-grid__column-hidden {
 	display: none;
 }

--- a/blocks/layout-grid/src/grid.scss
+++ b/blocks/layout-grid/src/grid.scss
@@ -32,6 +32,22 @@
 	overflow-wrap: break-word; // New standard.
 }
 
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__none > .block-editor-inner-blocks > .block-editor-block-list__layout {
+	grid-gap: $grid-gutter-none;
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__small > .block-editor-inner-blocks > .block-editor-block-list__layout {
+	grid-gap: $grid-gutter-small;
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__medium > .block-editor-inner-blocks > .block-editor-block-list__layout {
+	grid-gap: $grid-gutter-medium;
+}
+
+.wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__huge > .block-editor-inner-blocks > .block-editor-block-list__layout {
+	grid-gap: $grid-gutter-huge;
+}
+
 // Editor grid styles
 .wp-block-jetpack-layout-grid {
 	// These three rules are only necessary for Safari.

--- a/blocks/layout-grid/src/grid/css-classname.js
+++ b/blocks/layout-grid/src/grid/css-classname.js
@@ -144,7 +144,12 @@ export function removeGridClasses( classes ) {
 }
 
 export function getGutterClasses( { gutterSize, addGutterEnds } ) {
+	// Note that 'large' is the default and doesn't output any CSS class
 	return {
 		'wp-block-jetpack-layout-gutter__nowrap': ! addGutterEnds,
+		'wp-block-jetpack-layout-gutter__none': gutterSize === 'none',
+		'wp-block-jetpack-layout-gutter__small': gutterSize === 'small',
+		'wp-block-jetpack-layout-gutter__medium': gutterSize === 'medium',
+		'wp-block-jetpack-layout-gutter__huge': gutterSize === 'huge',
 	};
 }

--- a/blocks/layout-grid/src/grid/edit.js
+++ b/blocks/layout-grid/src/grid/edit.js
@@ -23,6 +23,7 @@ import {
 	Placeholder,
 	IsolatedEventContainer,
 	ToggleControl,
+	SelectControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { ENTER, SPACE } from '@wordpress/keycodes';
@@ -36,7 +37,7 @@ import { createBlock } from '@wordpress/blocks';
 
 import { getAsDeviceCSS, removeGridClasses, getGutterClasses } from './css-classname';
 import ColumnIcon from '../icons';
-import { getLayouts, getColumns, DEVICE_BREAKPOINTS, getSpanForDevice, getOffsetForDevice } from '../constants';
+import { getLayouts, getColumns, DEVICE_BREAKPOINTS, getSpanForDevice, getOffsetForDevice, getGutterValues } from '../constants';
 import { getGridWidth, getDefaultSpan } from './grid-defaults';
 import ResizeGrid from './resize-grid';
 import LayoutGrid from './layout-grid';
@@ -181,7 +182,7 @@ class Edit extends Component {
 		} = this.props;
 		const { selectedDevice } = this.state;
 		const extra = getAsDeviceCSS( selectedDevice, columns, attributes );
-		const { addGutterEnds } = attributes;
+		const { gutterSize, addGutterEnds } = attributes;
 		const layoutGrid = new LayoutGrid( attributes, selectedDevice, columns );
 		const classes = classnames(
 			removeGridClasses( className ),
@@ -275,7 +276,7 @@ class Edit extends Component {
 						</PanelBody>
 
 						<PanelBody title={ __( 'Responsive Breakpoints', 'layout-grid' ) }>
-							<p><em>{ __( "Note that previewing your post will show your browser's breakpoint, not the currently selected one." ) }</em></p>
+							<p><em>{ __( "Note that previewing your post will show your browser's breakpoint, not the currently selected one.", 'layout-grid' ) }</em></p>
 							<ButtonGroup>
 								{ getLayouts().map( ( layout ) => (
 									<Button
@@ -291,6 +292,15 @@ class Edit extends Component {
 
 							{ this.renderDeviceSettings( columns, selectedDevice, attributes ) }
 						</PanelBody>
+
+						<PanelBody title={ __( 'Gutter', 'layout-grid' ) }>
+							<p>{ __( 'Gutter size', 'layout-grid' ) }</p>
+
+							<SelectControl
+								value={ gutterSize }
+								onChange={ newValue => setAttributes( { gutterSize: newValue } ) }
+								options={ getGutterValues() }
+							/>
 
 						<PanelBody title={ __( 'Gutter', 'layout-grid' ) }>
 							<ToggleControl

--- a/blocks/layout-grid/src/grid/edit.js
+++ b/blocks/layout-grid/src/grid/edit.js
@@ -281,7 +281,6 @@ class Edit extends Component {
 								{ getLayouts().map( ( layout ) => (
 									<Button
 										key={ layout.value }
-										isDefault
 										isPrimary={ layout.value === selectedDevice }
 										onClick={ () => this.onChangeDevice( layout.value ) }
 									>
@@ -298,19 +297,18 @@ class Edit extends Component {
 
 							<SelectControl
 								value={ gutterSize }
-								onChange={ newValue => setAttributes( { gutterSize: newValue } ) }
+								onChange={ newValue => setAttributes( { gutterSize: newValue, addGutterEnds: newValue === 'none' ? false : addGutterEnds } ) }
 								options={ getGutterValues() }
 							/>
 
-						<PanelBody title={ __( 'Gutter', 'layout-grid' ) }>
-							<ToggleControl
+							{ gutterSize !== 'none' && <ToggleControl
 								label={ __( 'Add end gutters', 'layout-grid' ) }
 								help={
 									addGutterEnds ? __( 'Toggle off to remove the spacing left and right of the grid.', 'layout-grid' ) : __( 'Toggle on to add space left and right of the layout grid. ', 'layout-grid' )
 								}
 								checked={ addGutterEnds }
 								onChange={ newValue => setAttributes( { addGutterEnds: newValue } )  }
-							/>
+							/> }
 						</PanelBody>
 					</InspectorControls>
 

--- a/blocks/layout-grid/src/grid/edit.js
+++ b/blocks/layout-grid/src/grid/edit.js
@@ -24,6 +24,7 @@ import {
 	IsolatedEventContainer,
 	ToggleControl,
 	SelectControl,
+	Disabled,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { ENTER, SPACE } from '@wordpress/keycodes';
@@ -221,6 +222,17 @@ class Edit extends Component {
 			);
 		}
 
+		const toggleControl = (
+			<ToggleControl
+				label={ __( 'Add end gutters', 'layout-grid' ) }
+				help={
+					addGutterEnds ? __( 'Toggle off to remove the spacing left and right of the grid.', 'layout-grid' ) : __( 'Toggle on to add space left and right of the layout grid. ', 'layout-grid' )
+				}
+				checked={ addGutterEnds }
+				onChange={ newValue => setAttributes( { addGutterEnds: newValue } )  }
+			/>
+		);
+
 		return (
 			<IsolatedEventContainer>
 				<ResizeGrid
@@ -301,14 +313,12 @@ class Edit extends Component {
 								options={ getGutterValues() }
 							/>
 
-							{ gutterSize !== 'none' && <ToggleControl
-								label={ __( 'Add end gutters', 'layout-grid' ) }
-								help={
-									addGutterEnds ? __( 'Toggle off to remove the spacing left and right of the grid.', 'layout-grid' ) : __( 'Toggle on to add space left and right of the layout grid. ', 'layout-grid' )
-								}
-								checked={ addGutterEnds }
-								onChange={ newValue => setAttributes( { addGutterEnds: newValue } )  }
-							/> }
+							{ gutterSize === 'none' ? (
+								<Disabled>
+									{ toggleControl }
+								</Disabled>
+							) : toggleControl }
+
 						</PanelBody>
 					</InspectorControls>
 

--- a/blocks/layout-grid/src/index.js
+++ b/blocks/layout-grid/src/index.js
@@ -75,6 +75,10 @@ export function registerBlock() {
 				type: 'string',
 				default: 'full',
 			},
+			gutterSize: {
+				type: 'string',
+				default: 'large',
+			},
 			addGutterEnds: {
 				type: 'boolean',
 				default: true,

--- a/blocks/layout-grid/style.scss
+++ b/blocks/layout-grid/style.scss
@@ -16,9 +16,29 @@
 	padding-left: 24px;
 	padding-right: 24px;
 
+	&.wp-block-jetpack-layout-gutter__none {
+		padding-left: $padding-none;
+		padding-right: $padding-none;
+	}
+
+	&.wp-block-jetpack-layout-gutter__small {
+		padding-left: $padding-small;
+		padding-right: $padding-small;
+	}
+
+	&.wp-block-jetpack-layout-gutter__medium {
+		padding-left: $padding-medium;
+		padding-right: $padding-medium;
+	}
+
+	&.wp-block-jetpack-layout-gutter__huge {
+		padding-left: $padding-huge;
+		padding-right: $padding-huge;
+	}
+
 	&.wp-block-jetpack-layout-gutter__nowrap {
-		padding-left: 0;
-		padding-right: 0;
+		padding-left: $padding-none;
+		padding-right: $padding-none;
 	}
 
 	// Additional, user-set paddings.


### PR DESCRIPTION
Adds an option to adjust the layout grid gutter size:

![Edit_Post_‹_Latest_—_WordPress](https://user-images.githubusercontent.com/1277682/75970689-a3a21500-5ec8-11ea-85e7-52bc7fa085cd.jpg)

This affects the size of the gap between grid columns.

Huge:

![Edit_Post_‹_Latest_—_WordPress](https://user-images.githubusercontent.com/1277682/75970758-bcaac600-5ec8-11ea-949f-8f798cdc8b29.jpg)

Medium:

![Edit_Post_‹_Latest_—_WordPress](https://user-images.githubusercontent.com/1277682/75970793-c9c7b500-5ec8-11ea-8ed9-2036d84037a3.jpg)

Note that the left and right padding is also adjusted.

Fixes #30