### PR TITLE
Firefox fix for a cover block inside the grid block

### DIFF
--- a/blocks/layout-grid/front.css
+++ b/blocks/layout-grid/front.css
@@ -690,3 +690,7 @@
   .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column * {
     word-break: break-word;
     word-wrap: break-word; }
+
+@-moz-document url-prefix() {
+  .wp-block-jetpack-layout-grid .wp-block-cover {
+    max-height: 0; } }

--- a/blocks/layout-grid/front.scss
+++ b/blocks/layout-grid/front.scss
@@ -106,4 +106,11 @@
 		word-break: break-word;
 		word-wrap: break-word;
 	}
+
+	// Fixes an issue in Firefox where a block in the grid with 100% height causes the grid to increase in height
+	@-moz-document url-prefix() {
+		.wp-block-cover {
+			max-height: 0;
+		}
+	}
 }


### PR DESCRIPTION
Firefox exhibits different grid behaviour to other browsers when a cover block follows another block inside the same grid column.

Here is an example two column grid with the first column containing an image and a cover block:

![Add_New_Post_‹_Latest_—_WordPress](https://user-images.githubusercontent.com/1277682/75989596-72870c00-5eeb-11ea-9632-7c71df58b673.jpg)

When viewed in Chrome and Safari this displays correctly:

![firefox_–_Latest](https://user-images.githubusercontent.com/1277682/75989646-87639f80-5eeb-11ea-8c23-152738841327.jpg)

When viewed in Firefox the cover block breaks out of the grid:

![firefox_–_Latest_-_Mozilla_Firefox](https://user-images.githubusercontent.com/1277682/75989712-a5310480-5eeb-11ea-93a2-11897cf553ab.jpg)

This PR applies a a `max-height: 0` which fixes the problem (props to @jasmussen). The fix is specific to Firefox and the cover block. There may be other blocks that cause a similar issue, and they will need to be 'fixed' on an individual basis.

If the behaviour of Firefox changes in the future we can think about removing this fix. 

## Testing

1) Create a two column grid block. In the first column add an image and a cover block (with image)
2) View the post in Firefox and note that it breaks out of the bottom of the post
3) Apply PR
4) View the post in Firefox again and note that the cover is contained


Fixes #27 