### PR TITLE
Fix bauhaus button deprecation warnings

### DIFF
--- a/blocks/bauhaus-centenary/src/edit.js
+++ b/blocks/bauhaus-centenary/src/edit.js
@@ -16,7 +16,7 @@ import {
 import {
 	PanelBody,
 	Placeholder,
-	IconButton,
+	Button,
 } from '@wordpress/components';
 import { ENTER } from '@wordpress/keycodes';
 
@@ -139,10 +139,10 @@ const Edit = ( {
 					className={ className }
 				>
 					{ Object.entries( categories ).map( ( [ category, { label, icon } ] ) => (
-						<IconButton
+						<Button
 							className="icon-button"
 							icon={ icon }
-							isDefault
+							isSecondary
 							key={ category }
 							label={ label }
 							onClick={ () => setAttributes( { category } ) }

--- a/blocks/bauhaus-centenary/src/radio-button-group.js
+++ b/blocks/bauhaus-centenary/src/radio-button-group.js
@@ -26,7 +26,7 @@ const RadioButtonGroup = ( { options, selected, onChange, className, ...props } 
 				role="radio"
 				aria-checked={ selected === value }
 				isPrimary={ selected === value }
-				isDefault={ selected !== value }
+				isSecondary={ selected !== value }
 				onClick={ () => onChange( value ) }
 			>
 				{ label }


### PR DESCRIPTION
There were a few deprecation warnings that were easy enough to fix quickly

`IconButton` is replaced by `Button` and `isDefault` is replaced by `isSecondary`