### PR TITLE
Fix only load canvas with block

### DIFF
--- a/blocks/motion-background/index.php
+++ b/blocks/motion-background/index.php
@@ -9,18 +9,31 @@ add_action( 'init', function() {
 } );
 
 add_action( 'enqueue_block_assets', function() {
-	wp_enqueue_script(
-		'wpcom-twgl-js',
-		plugins_url( 'twgl/twgl.js', __FILE__ ),
-		[], // no dependencies
-		filemtime( plugin_dir_path( __FILE__ ) . 'twgl/twgl.js' ),
-		true // in footer
-	);
-	wp_enqueue_script(
-		'wpcom-motion-background-js',
-		plugins_url( 'motion-background.js', __FILE__ ),
-		[ 'wpcom-twgl-js', 'lodash' ],
-		filemtime( plugin_dir_path( __FILE__ ) . 'motion-background.js' ),
-		true // in footer
-	);
+	// https://github.com/WordPress/gutenberg/issues/14758#issuecomment-478912504
+	function some_posts_have_block( $block_type ) {
+		global $wp_the_query;
+		foreach ( $wp_the_query->posts as $post ) {
+			if ( has_block( $block_type, $post ) ) {
+				return TRUE;
+			}
+		}
+		return FALSE;
+	}
+
+	if ( ! is_admin() && some_posts_have_block( 'a8c/motion-background' ) ) {
+		wp_enqueue_script(
+			'wpcom-twgl-js',
+			plugins_url( 'twgl/twgl.js', __FILE__ ),
+			[], // no dependencies
+			filemtime( plugin_dir_path( __FILE__ ) . 'twgl/twgl.js' ),
+			true // in footer
+		);
+		wp_enqueue_script(
+			'wpcom-motion-background-js',
+			plugins_url( 'motion-background.js', __FILE__ ),
+			[ 'wpcom-twgl-js', 'lodash' ],
+			filemtime( plugin_dir_path( __FILE__ ) . 'motion-background.js' ),
+			true // in footer
+		);
+	}
 } );

--- a/blocks/motion-background/motion-background.js
+++ b/blocks/motion-background/motion-background.js
@@ -4,10 +4,6 @@
  */
 
 ( function( _, twgl ) {
-	if ( document.getElementById( 'editor' ) ) {
-		return; // TODO: disable this properly rather than with this return
-	}
-
 	const blocks = document.getElementsByClassName( 'wp-block-a8c-motion-background' );
 
 	const gl = twgl.getWebGLContext( document.createElement( 'canvas' ) );


### PR DESCRIPTION
Pages without the motion-background still had a canvas applied and the WebGL code running. This disables the script from loading if the page doesn't contain the block.

And since the editor has the animation code bundled, we can prevent the frontend code from loading in the editor as well.