### PR TITLE
Fix canvas z-index when viewing post

### DIFF
--- a/blocks/motion-background/editor.scss
+++ b/blocks/motion-background/editor.scss
@@ -20,3 +20,7 @@
 		flex-grow: 1;
 	}
 }
+
+.wp-block-a8c-motion-background-canvas {
+	z-index: 0;
+}

--- a/blocks/motion-background/style.scss
+++ b/blocks/motion-background/style.scss
@@ -18,4 +18,5 @@
 	height: 100%;
 	top: 0;
 	left: 0;
+	z-index: -1;
 }


### PR DESCRIPTION
When viewing a post, some links were not clickable because the canvas was covering them. This forces the canvas underneath the links so they are clickable again.

The editor handles the layering with an extra component, so the z-index isn't needed there.