### PR TITLE
Improve/create preview for Image Compare block.

### DIFF
--- a/blocks/image-compare/editor.scss
+++ b/blocks/image-compare/editor.scss
@@ -36,3 +36,48 @@
 [data-type="jetpack/image-compare-block"]:not(.is-selected) .image-compare__comparison {
 	pointer-events: none;
 }
+
+// When juxtapose isn't loaded, we style the block to resemble the end result.
+// This effectively styles the block to look good in the block preview.
+.juxtapose .components-placeholder {
+	border: none;
+	padding: 0;
+	box-shadow: none;
+
+	.components-placeholder__label {
+		display: none;
+	}
+
+	.image-compare__image-before,
+	.image-compare__image-after {
+		padding: 0;
+		flex: none;
+		width: 100%;
+	}
+
+	&::before {
+		content: "";
+		display: block;
+		position: absolute;
+		z-index: 2;
+		width: 100%;
+		height: 4px;
+		background: white;
+	}
+
+	// Show a side by side previe.
+	.image-compare__image-after {
+		position: absolute;
+		width: 100%;
+		height: 50%;
+		overflow: hidden;
+
+		img {
+			width: 100%;
+			height: 200%;
+			max-width: none;
+			display: flex;
+			align-self: flex-end;
+		}
+	}
+}


### PR DESCRIPTION
This PR styles the preview of the Image Compare block to better resemble the block itself. Fixes #55.

<img width="715" alt="Screenshot 2020-03-23 at 10 37 34" src="https://user-images.githubusercontent.com/1204802/77303091-9f605f00-6cf2-11ea-82df-38cfe245e121.png">

I did try first a horizontal split, because that's the default. But the two images that we are hotlinking (with permission) from Wikimedia do not align well in that state:

<img width="720" alt="Screenshot 2020-03-23 at 10 34 44" src="https://user-images.githubusercontent.com/1204802/77303136-b2732f00-6cf2-11ea-84ab-37af2f4c16fb.png">
