### PR TITLE
Image Compare - fix images when window resized

### DIFF
--- a/blocks/image-compare/src/edit.js
+++ b/blocks/image-compare/src/edit.js
@@ -1,8 +1,15 @@
 /**
+ * External dependencies
+ */
+import { debounce } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { InspectorControls, RichText } from '@wordpress/block-editor';
 import { PanelBody, RadioControl, Placeholder } from '@wordpress/components';
+import { useResizeObserver } from '@wordpress/compose';
+import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -27,8 +34,32 @@ const edit = ( { attributes, isSelected, setAttributes } ) => {
 	// If both images are set, add juxtaspose class, which is picked up by the library.
 	const classes = ( imageBeforeUrl && imageAfterUrl ) ? 'image-compare__comparison juxtapose' : 'image-compare__placeholder';
 
+	// Let's look for resize so we can trigger the thing
+	const [ resizeListener, sizes ] = useResizeObserver();
+	useEffect(
+		debounce(
+			() => {
+				// debounce
+				if ( juxtapose && juxtapose.sliders ) {
+					// get width
+					const fig = document.getElementsByClassName("wp-block-jetpack-image-compare-block");
+					const width = ( fig ) ? fig[0].offsetWidth : 0;
+					if ( width > 0 ) {
+						juxtapose.sliders.forEach( elem => {
+							elem.optimizeWrapper(width);
+						} );
+					}
+				}
+			},
+			200
+		),
+		[sizes.width]
+	);
+
+
 	return (
 		<figure className="wp-block-jetpack-image-compare-block">
+			{ resizeListener }
 			<InspectorControls key="controls">
 				<PanelBody title={ __( 'Orientation' ) }>
 					<RadioControl
@@ -50,7 +81,9 @@ const edit = ( { attributes, isSelected, setAttributes } ) => {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<div className={ classes } data-mode={ orientation }>
+			<div
+				className={ classes }
+				data-mode={ orientation }>
 
 				<Placeholder>
 					<div className="image-compare__image-before">

--- a/blocks/image-compare/src/edit.js
+++ b/blocks/image-compare/src/edit.js
@@ -19,7 +19,7 @@ import UploadPlaceholder from './upload-placeholder';
 
 /* global juxtapose */
 
-const edit = ( { attributes, isSelected, setAttributes } ) => {
+const edit = ( { attributes, clientId, isSelected, setAttributes } ) => {
 	const {
 		imageBeforeId,
 		imageBeforeUrl,
@@ -39,14 +39,15 @@ const edit = ( { attributes, isSelected, setAttributes } ) => {
 	useEffect(
 		debounce(
 			() => {
-				// debounce
 				if ( juxtapose && juxtapose.sliders ) {
 					// get width
-					const fig = document.getElementsByClassName("wp-block-jetpack-image-compare-block");
-					const width = ( fig ) ? fig[0].offsetWidth : 0;
-					if ( width > 0 ) {
+					if ( sizes &&  sizes.width > 0 ) {
+						// only update this slide
 						juxtapose.sliders.forEach( elem => {
-							elem.optimizeWrapper(width);
+							const parentElem = elem.wrapper.parentElement;
+							if ( parentElem.id === clientId ) {
+								elem.optimizeWrapper(sizes.width);
+							}
 						} );
 					}
 				}
@@ -58,7 +59,7 @@ const edit = ( { attributes, isSelected, setAttributes } ) => {
 
 
 	return (
-		<figure className="wp-block-jetpack-image-compare-block">
+		<figure className="wp-block-jetpack-image-compare-block" id={ clientId }>
 			{ resizeListener }
 			<InspectorControls key="controls">
 				<PanelBody title={ __( 'Orientation' ) }>

--- a/blocks/image-compare/src/edit.js
+++ b/blocks/image-compare/src/edit.js
@@ -16,6 +16,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import UploadPlaceholder from './upload-placeholder';
+import useDebounce from './use-debounce';
 
 /* global juxtapose */
 
@@ -36,27 +37,21 @@ const edit = ( { attributes, clientId, isSelected, setAttributes } ) => {
 
 	// Let's look for resize so we can trigger the thing
 	const [ resizeListener, sizes ] = useResizeObserver();
-	useEffect(
-		debounce(
-			() => {
-				if ( juxtapose && juxtapose.sliders ) {
-					// get width
-					if ( sizes &&  sizes.width > 0 ) {
-						// only update this slide
-						juxtapose.sliders.forEach( elem => {
-							const parentElem = elem.wrapper.parentElement;
-							if ( parentElem.id === clientId ) {
-								elem.optimizeWrapper(sizes.width);
-							}
-						} );
-					}
-				}
-			},
-			200
-		),
-		[sizes.width]
-	);
+	const debouncedSize = useDebounce(sizes.width, 100);
 
+	useEffect( () => {
+		if ( sizes &&  sizes.width > 0 ) {
+			if ( juxtapose && juxtapose.sliders ) {
+				// only update for *this* slide
+				juxtapose.sliders.forEach( elem => {
+					const parentElem = elem.wrapper.parentElement;
+					if ( parentElem.id === clientId ) {
+						elem.optimizeWrapper(sizes.width);
+					}
+				} );
+			}
+		}
+	}, [debouncedSize] );
 
 	return (
 		<figure className="wp-block-jetpack-image-compare-block" id={ clientId }>

--- a/blocks/image-compare/src/use-debounce.js
+++ b/blocks/image-compare/src/use-debounce.js
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+
+export default (value, timeout) => {
+	const [state, setState] = useState(value);
+
+	useEffect(() => {
+		const handler = setTimeout(() => setState(value), timeout);
+		return () => clearTimeout(handler);
+	}, [value]);
+
+	return state;
+}


### PR DESCRIPTION
The photos aren't resized properly when the window is resized.

<img width="767" alt="Screenshot 2020-03-23 at 13 54 12" src="https://user-images.githubusercontent.com/45363/77570052-69ed7a00-6e88-11ea-8194-5f3f32e56a23.png">

This PR adds using the `useResizeObserver` hook to trigger calling the optimizeWrapper function.