### PR TITLE
Switch load handlers to block-experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ A monorepo of block experiments by the fine folks at Automattic.
 
 ### About
 
-This repository holds a collection of blocks allowing a single place to develop, test, and package. Plus it allows a single place for user's to submit issues. 
+This repository holds a collection of blocks allowing a single place to develop, test, and package. Plus it allows a single place for user's to submit issues.
 
 To make development easier, the build script allows for building and bundling all of the blocks together.
 
 For packaging, each block can be generated as its own stand-alone plugin.
 
 
-## Development 
+## Development
 
 1. Install node packages: `yarn install`
 
@@ -19,7 +19,7 @@ For packaging, each block can be generated as its own stand-alone plugin.
    (or)
    Run a production build with: `yarn build`
 
-3. Once built, add copy this directory (or add a symlink) to your plugins directory. 
+3. Once built, add copy this directory (or add a symlink) to your plugins directory.
 
 4. Activate Block Experiments plugin, use blocks in Editor.
 
@@ -36,9 +36,9 @@ When registering your block, use these values so it works when used inside of th
 
 ```php
 register_block_type( 'jetpack/your-block-name', [
-	'editor_script' => 'wpcom-blocks',
-	'style' => 'wpcom-blocks',
-	'editor_style' => 'wpcom-blocks-editor',
+	'editor_script' => 'block-experiments',
+	'style' => 'block-experiments',
+	'editor_style' => 'block-experiments-editor',
 ] );
 ```
 

--- a/block-experiments.php
+++ b/block-experiments.php
@@ -6,7 +6,7 @@
  * Version:     1.0.0
  * Author:      Automattic
  * Author URI:  https://automattic.com
- * Text Domain: wpcom-blocks
+ * Text Domain: block-experiments
  * License:     GPL v2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
  */
@@ -94,7 +94,7 @@ add_action( 'init', function() {
 
 	// Block JS
 	wp_register_script(
-		'wpcom-blocks',
+		'block-experiments',
 		plugins_url( 'build/index.js', __FILE__ ),
 		$dependencies,
 		$version,
@@ -103,7 +103,7 @@ add_action( 'init', function() {
 
 	// Block front end style
 	wp_register_style(
-		'wpcom-blocks',
+		'block-experiments',
 		plugins_url( 'build/style.css', __FILE__ ),
 		[],
 		filemtime( plugin_dir_path( __FILE__ ) . 'build/style.css' )
@@ -111,7 +111,7 @@ add_action( 'init', function() {
 
 	// Block editor style
 	wp_register_style(
-		'wpcom-blocks-editor',
+		'block-experiments-editor',
 		plugins_url( 'build/editor.css', __FILE__ ),
 		[],
 		filemtime( plugin_dir_path( __FILE__ ) . 'build/editor.css' )

--- a/blocks/bauhaus-centenary/index.php
+++ b/blocks/bauhaus-centenary/index.php
@@ -10,9 +10,9 @@ add_action( 'init', function() {
 	register_block_type(
 		'a8c/bauhaus-centenary',
 		[
-			'editor_script'   => 'wpcom-blocks',
-			'style'           => 'wpcom-blocks',
-			'editor_style'    => 'wpcom-blocks-editor',
+			'editor_script'   => 'block-experiments',
+			'style'           => 'block-experiments',
+			'editor_style'    => 'block-experiments-editor',
 		]
 	);
 

--- a/blocks/event/index.php
+++ b/blocks/event/index.php
@@ -2,8 +2,8 @@
 
 add_action( 'init', function() {
 	register_block_type( 'jetpack/event', [
-		'editor_script' => 'wpcom-blocks',
-		'style' => 'wpcom-blocks',
-		'editor_style' => 'wpcom-blocks-editor',
+		'editor_script' => 'block-experiments',
+		'style' => 'block-experiments',
+		'editor_style' => 'block-experiments-editor',
 	] );
 } );

--- a/blocks/image-compare/src/edit.js
+++ b/blocks/image-compare/src/edit.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { debounce } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { InspectorControls, RichText } from '@wordpress/block-editor';

--- a/blocks/layout-grid/index.php
+++ b/blocks/layout-grid/index.php
@@ -2,15 +2,15 @@
 
 add_action( 'init', function() {
 	register_block_type( 'jetpack/layout-grid', [
-		'editor_script' => 'wpcom-blocks',
-		'style' => 'wpcom-blocks',
-		'editor_style' => 'wpcom-blocks-editor',
+		'editor_script' => 'block-experiments',
+		'style' => 'block-experiments',
+		'editor_style' => 'block-experiments-editor',
 	] );
 
 	register_block_type( 'jetpack/layout-grid-column', [
-		'editor_script' => 'wpcom-blocks',
-		'style' => 'wpcom-blocks',
-		'editor_style' => 'wpcom-blocks-editor',
+		'editor_script' => 'block-experiments',
+		'style' => 'block-experiments',
+		'editor_style' => 'block-experiments-editor',
 	] );
 
 	wp_set_script_translations( 'jetpack/layout-grid', 'layout-grid' );

--- a/blocks/motion-background/index.php
+++ b/blocks/motion-background/index.php
@@ -2,9 +2,9 @@
 
 add_action( 'init', function() {
 	register_block_type( 'a8c/motion-background', [
-		'editor_script' => 'wpcom-blocks',
-		'style' => 'wpcom-blocks',
-		'editor_style' => 'wpcom-blocks-editor',
+		'editor_script' => 'block-experiments',
+		'style' => 'block-experiments',
+		'editor_style' => 'block-experiments-editor',
 	] );
 } );
 

--- a/blocks/rich-image/index.php
+++ b/blocks/rich-image/index.php
@@ -4,9 +4,9 @@ require_once __DIR__ . '/rest-api.php';
 
 add_action( 'init', function() {
 	register_block_type( 'jetpack/rich-image', [
-		'editor_script' => 'wpcom-blocks',
-		'style' => 'wpcom-blocks',
-		'editor_style' => 'wpcom-blocks-editor',
+		'editor_script' => 'block-experiments',
+		'style' => 'block-experiments',
+		'editor_style' => 'block-experiments-editor',
 	] );
 } );
 

--- a/blocks/starscape/index.php
+++ b/blocks/starscape/index.php
@@ -2,9 +2,9 @@
 
 add_action( 'init', function() {
 	register_block_type( 'a8c/starscape', [
-		'editor_script' => 'wpcom-blocks',
-		'style' => 'wpcom-blocks',
-		'editor_style' => 'wpcom-blocks-editor',
+		'editor_script' => 'block-experiments',
+		'style' => 'block-experiments',
+		'editor_style' => 'block-experiments-editor',
 	] );
 
 	wp_set_script_translations( 'a8c/starscape', 'starscape' );

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ import { TinkerBlocksLogo } from './block-icons';
 
 setCategories( [
 	{
-		slug: 'wpcom-blocks',
+		slug: 'block-experiments',
 		title: 'Block Experiments',
 		icon: <TinkerBlocksLogo />,
 	},


### PR DESCRIPTION

Moves the load handlers from wpcom-blocks to block-experiments.

Fixes https://github.com/Automattic/wpcom-blocks/issues/166
