### PR TITLE
Grid block version 2!

### DIFF
--- a/blocks/layout-grid/editor.scss
+++ b/blocks/layout-grid/editor.scss
@@ -21,29 +21,12 @@
 	margin: 0;
 	padding-left: 0;
 	padding-right: 0;
-
-	// 3. Unset for contents of container.
-	// @todo Revisit/remove for 5.4.
-	> .block-editor-block-list__block-edit {
-		padding-left: 0;
-		margin-left: 0;
-		padding-right: 0;
-		margin-right: 0;
-	}
 }
 
 
 /**
  * Visual Glitches
  */
-
-[data-type="jetpack/layout-grid"] {
-	// Pending refinements, hide the v6.3 dashed outlines on grid children, they aren't helpful here.
-	// @todo Revisit/remove for 5.4.
-	.block-editor-block-list__block:not(.is-selected) > .block-editor-block-list__block-edit::before {
-		border-color: transparent !important;
-	}
-}
 
 // Make sure each column is full height in the editor, as it is on the frontend.
 [data-type="jetpack/layout-grid-column"] > .block-editor-block-list__block-edit,
@@ -68,49 +51,10 @@
 	align-items: center;
 
 	// Fit available space.
-	// This rule is for newer versions of the plugin and WordPress 5.4.
-	> div {
+	.is-block-content {
 		width: 100%;
 	}
-
-	// This rule is for older versions of the plugin and WordPress 5.3.
-	// @todo Revisit/remove for 5.4.
-	> .block-editor-block-list__block-edit {
-		transition: all .1s ease;
-
-		// The 58px here come from the padding applied to the body container.
-		// @todo, consider a more upgrade friendly method so this doesn't need to be aware of Gutenberg changes.
-		width: calc( 100% + 58px + 58px );
-
-		// Make an exception for the group, which zeroes out a margin we need.
-		.wp-block-group & {
-			width: 100%;
-		}
-	}
 }
-
-// Try hiding the alignments dropdown.
-// The grid is only consistent across blocks, if every grid block has the same alignment, ideally full-wide.
-[data-type="jetpack/layout-grid"] > .block-editor-block-list__block-edit > .block-editor-block-contextual-toolbar > .block-editor-block-toolbar > .block-editor-block-switcher + .block-editor-block-toolbar__slot {
-	display: none;
-}
-
-// Hide the hover style & breadcrumbs for individual column containers.
-// This helps simplify the experience for resizing columns.
-// The hover effect may be removed entirely upstream, in which case we can remove this.
-// @todo Revisit/remove for 5.4.
-[data-type="jetpack/layout-grid-column"].is-hovered > .block-editor-block-list__block-edit {
-	// Don't show breadcrumbs.
-	> .block-editor-block-list__breadcrumb {
-		display: none;
-	}
-
-	// Don't show outline.
-	&::before {
-		content: none;
-	}
-}
-
 
 /**
  * Inspector Controls
@@ -186,8 +130,8 @@
 	font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
 	font-size: 13px;
 	position: absolute;
-	bottom: -24px - 14px;
-	left: -3px;
+	bottom: -24px;
+	left: 0;
 	padding: 0 8px;
 	height: 24px;
 	background-color: rgba(0,0,0,0.8);
@@ -198,4 +142,62 @@
 [data-type="jetpack/layout-grid"].has-child-selected .jetpack-layout-grid-previewing,
 [data-type="jetpack/layout-grid"].is-selected .jetpack-layout-grid-previewing {
 	display: block;
+}
+
+
+/**
+ * Redesign resize handles to handle literal edge cases.
+ */
+
+[data-type="jetpack/layout-grid"] {
+
+	// New vertical appearance.
+	.components-resizable-box__side-handle {
+		// Make the circle a pill shape instead.
+		&::after {
+			width: 8px;
+			border: none;
+			border-radius: 2px;
+			height: 24px;
+			top: calc(50% - 12px);
+			right: calc(50% - 4px);
+		}
+
+		// Adjust the vertical separator.
+		&::before {
+			width: 2px;
+			right: calc(50% - 1px);
+			border: none;
+		}
+	}
+
+	// Provide special treatment for the drag handles when the end-gutters are enabled, as they will otherwise cause scrollbars.
+	.wp-block-jetpack-layout-gutter__nowrap {
+
+		.components-resizable-box__side-handle.components-resizable-box__handle-right {
+			right: 0;
+
+			&::before,
+			&::after {
+				right: 0;
+			}
+		}
+
+		.components-resizable-box__side-handle.components-resizable-box__handle-left {
+			left: 0;
+
+			&::before,
+			&::after {
+				left: 0;
+			}
+		}
+
+		// On 5.4, when end-gutters are untoggled, collapse the left and right borders.
+		// This avoids a horizontal scrollbar that would otherwise appear.
+		// @todo: Can be removed when the G2 UI is merged, likely 5.5.
+		.wp-block::before {
+			right: 0;
+			left: 0;
+		}
+	}
 }

--- a/blocks/layout-grid/editor.scss
+++ b/blocks/layout-grid/editor.scss
@@ -56,6 +56,13 @@
 	}
 }
 
+// Make the columns appender margin match the default block margin.
+// @todo: this margin will possibly be retired in the future. Revisit then.
+.wp-block-jetpack-layout-grid-column > .block-editor-inner-blocks > .block-editor-block-list__layout > .block-list-appender {
+	margin: 28px 0;
+}
+
+
 /**
  * Inspector Controls
  */

--- a/blocks/layout-grid/editor.scss
+++ b/blocks/layout-grid/editor.scss
@@ -159,7 +159,8 @@
 [data-type="jetpack/layout-grid"] {
 
 	// New vertical appearance.
-	.components-resizable-box__side-handle {
+	.wpcom-overlay-resize__handle .components-resizable-box__side-handle,
+	.wp-blocks-jetpack-layout-grid__resize-handles .components-resizable-box__side-handle {
 		// Make the circle a pill shape instead.
 		&::after {
 			width: 8px;
@@ -181,8 +182,9 @@
 	// Provide special treatment for the drag handles when the end-gutters are enabled, as they will otherwise cause scrollbars.
 	.wp-block-jetpack-layout-gutter__nowrap {
 
-		.components-resizable-box__side-handle.components-resizable-box__handle-right {
-			right: 0;
+		.wpcom-overlay-resize__handle .components-resizable-box__side-handle.components-resizable-box__handle-right,
+		.wp-blocks-jetpack-layout-grid__resize-handles .components-resizable-box__side-handle.components-resizable-box__handle-right {
+				right: 0;
 
 			&::before,
 			&::after {
@@ -190,7 +192,8 @@
 			}
 		}
 
-		.components-resizable-box__side-handle.components-resizable-box__handle-left {
+		.wpcom-overlay-resize__handle .components-resizable-box__side-handle.components-resizable-box__handle-left,
+		.wp-blocks-jetpack-layout-grid__resize-handles .components-resizable-box__side-handle.components-resizable-box__handle-left {
 			left: 0;
 
 			&::before,

--- a/blocks/layout-grid/src/grid-column/edit.js
+++ b/blocks/layout-grid/src/grid-column/edit.js
@@ -83,7 +83,7 @@ class Edit extends Component {
 		return (
 			<div className={ classes } style={ style }>
 				<span className="wp-blocks-jetpack-layout-grid__resize-handles">
-					<div
+					<div 
 						className="components-resizable-box__handle components-resizable-box__side-handle components-resizable-box__handle-right"
 						onMouseDown={ this.onRightIn }
 						data-resize-right

--- a/blocks/layout-grid/src/grid-overlay.scss
+++ b/blocks/layout-grid/src/grid-overlay.scss
@@ -31,7 +31,6 @@
 	padding-right: 24px;
 
 	// Lower the z-index so it's under the block borders.
-	// @todo: Verify this doesn't mess with alternate templates and background styles.
 	z-index: 0;
 
 	.wpcom-overlay-grid__column {

--- a/blocks/layout-grid/src/grid-resize.scss
+++ b/blocks/layout-grid/src/grid-resize.scss
@@ -12,37 +12,10 @@
 	width: 100%;
 	height: 100%;
 	touch-action: none;
-	// When resizing we switch to absolute positioning
-	&:not(.wpcom-resize-grid__resizing) {
-		display: grid;
-		grid-gap: 24px;
-		grid-template-columns: $grid-desktop;
 
-		// This padding adds end gutters.
-		padding-left: 24px;
-		padding-right: 24px;
-	}
-
-	// Reset inherited negative margins.
-	// These margins are in the block editor to compensate for the 14px block padding on all blocks.
-	// They don't play well with CSS Grid, so we reset them, and re-apply them later.
-	margin-left: 0;
-	margin-right: 0;
-
-	// Every block, including nested blocks, are born with an intrinsic minimum margin.
-	// This resets that for the containers, which aren't meant to have that intrinsically.
-	> .wp-block > .block-editor-block-list__block-edit > [data-block] {
-		margin-top: 0;
-		margin-bottom: 0;
-	}
-
+	// Likely necessary to override bleed from themes.
 	.wp-block {
 		max-width: none;
-	}
-
-	&.wpcom-resize-grid__resizing .wpcom-resize-grid__column-resizing {
-		position: absolute !important;
-		height: 100%;
 	}
 }
 
@@ -79,46 +52,4 @@
 
 body.is-resizing [data-type="jetpack/layout-grid"] {
 	overflow: inherit;
-}
-
-
-/**
- * Scale down the Grid Block when Selected.
- */
-
-
-// When the block is selected, we scale it down to make room for the side UI.
-// This becomes unnecessary with https://github.com/WordPress/gutenberg/pull/19344.
-// @todo Revisit/remove for 5.4.
-
-// This rule is for newer versions of the plugin and WordPress 5.4.
-[data-type="jetpack/layout-grid"][data-align="full"].has-child-selected,
-[data-type="jetpack/layout-grid"][data-align="full"].is-selected,
-body.is-resizing [data-type="jetpack/layout-grid"][data-align="full"] {
-	width: 100%;
-	margin-left: auto;
-	margin-right: auto;
-
-	&::before {
-		border-right-width: 1px;
-	}
-
-	// @todo Remove for 5.4, as it won't be necessary.
-	.block-editor-block-list__block-edit::before {
-		border-right-width: 1px;
-	}
-}
-
-// This rule is for older versions of the plugin and WordPress 5.3.
-[data-type="jetpack/layout-grid"][data-align="full"].has-child-selected,
-[data-type="jetpack/layout-grid"][data-align="full"].is-selected,
-body.is-resizing [data-type="jetpack/layout-grid"][data-align="full"] {
-	> .block-editor-block-list__block-edit {
-		width: calc( 100% + 30px + 30px + 8px ); // The 30 are from the canvas side padding (58px) minus the width of the side UI (28px).
-
-		// Make an exception for the group, which zeroes out a margin we need.
-		.wp-block-group & {
-			width: calc( 100% - 28px - 28px - 8px );
-		}
-	}
 }

--- a/blocks/layout-grid/src/grid.scss
+++ b/blocks/layout-grid/src/grid.scss
@@ -148,7 +148,7 @@
 }
 
 // These colors are copied from upstream Gutenberg to ensure opacities when the theme is dark.
-// @todo Revisit/remove for 5.4.
+// @todo: Can be removed when the G2 UI is merged, likely 5.5.
 $dark-opacity-light-800: rgba(#425863, 0.4);
 $light-opacity-light-800: rgba(#fff, 0.45);
 
@@ -164,7 +164,7 @@ $light-opacity-light-800: rgba(#fff, 0.45);
 		left: 0;
 		right: 0;
 
-		border-color:  $dark-opacity-light-800;
+		border-color: $dark-opacity-light-800;
 		border-left: 1px dashed $dark-opacity-light-800;
 		border-style: dashed;
 		border-width: 1px;

--- a/blocks/layout-grid/src/grid/resize-grid/index.js
+++ b/blocks/layout-grid/src/grid/resize-grid/index.js
@@ -11,7 +11,7 @@ import classnames from 'classnames';
 import { Component, createRef } from '@wordpress/element';
 
 /**
- * Local dependencies
+ * Internal dependencies
  */
 
 import findNearest from './nearest';
@@ -191,7 +191,7 @@ class ResizeGrid extends Component {
 
 		return (
 			<div className={ classes } onMouseDown={ this.onMouseDown } onTouchStart={ this.onMouseDown } ref={ this.containerRef }>
-				{ resizingColumn !== -1 && <ResizeHandle height={ height } xPos={ xPos } top={ this.state.top } isSelected={ isSelected } /> }
+				{ resizingColumn !== -1 && <ResizeHandle direction={ this.state.direction } height={ height } xPos={ xPos } top={ this.state.top } isSelected={ isSelected } /> }
 				{ children }
 			</div>
 		);

--- a/blocks/layout-grid/src/grid/resize-grid/resize-handle.js
+++ b/blocks/layout-grid/src/grid/resize-grid/resize-handle.js
@@ -4,7 +4,7 @@
 
 import classnames from 'classnames';
 
-const ResizeHandle = ( { height, xPos, top, isSelected } ) => {
+const ResizeHandle = ( { direction, height, xPos, top, isSelected } ) => {
 	const classes = classnames( 'wpcom-overlay-resize__handle', 'components-resizable-box__container', {
 		'is-selected': isSelected,
 	} );
@@ -17,10 +17,20 @@ const ResizeHandle = ( { height, xPos, top, isSelected } ) => {
 		left: xPos + 'px',
 	};
 
+
+	const handleClasses = classnames(
+		'components-resizable-box__handle',
+		'components-resizable-box__side-handle',
+		{
+			'components-resizable-box__handle-left': direction === 'left',
+			'components-resizable-box__handle-right': direction === 'right',
+		}
+	);
+
 	return (
 		<div className={ classes } style={ wrapStyle }>
 			<span>
-				<div className="components-resizable-box__handle components-resizable-box__side-handle components-resizable-box__handle-left" style={ dragStyle }></div>
+				<div className={ handleClasses } style={ dragStyle }></div>
 			</span>
 		</div>
 	);

--- a/blocks/layout-grid/src/index.js
+++ b/blocks/layout-grid/src/index.js
@@ -32,7 +32,7 @@ function getColumnAttributes( total, breakpoints ) {
 export function registerBlock() {
 	registerBlockType( 'jetpack/layout-grid', {
 		title: __( 'Layout Grid', 'layout-grid' ),
-		description: __( 'Align blocks to to a global grid, with support for responsive breakpoints.', 'layout-grid' ),
+		description: __( 'Align blocks to a global grid, with support for responsive breakpoints.', 'layout-grid' ),
 		icon: GridIcon,
 		category: 'layout',
 		supports: {


### PR DESCRIPTION
This PR does a number of things to polish the grid block. But right up front, it does kind of change the requirements, but to something I think is reasonable:

- It now requires WordPress 5.4, 
- OR it requires the Gutenberg plugin version 7.7 or higher.

It should _work_ with 5.3, but the layout may not be ideal in all situations. This is speaking of the _editor_ view — the frontend appearance should be unchanged and work wherever. 

Video: https://cloudup.com/c_pvr3hp9oi

It does these things:

- It rethinks the UI in a world where the G2 UI exists. That is — no more unsetting of paddings and margins, but instead embracing the footprint of each block.
- As a result, much hacky code has been removed.
- Also as a result, the grid now no longer "sizes down" when selected, which fixes some regressions we've seen from the hacks that made that work. 
- Polish to the appender, and fixing a typo.

The new approach is much more resilient.

- Drag handles have been redesigned to be simpler and more G2-esque. If this works well, we can look at submitting this to the core project. 
- When the block is full-wide and has end-gutters, no change.
- When the block is full-wide and hides end-gutters, drag handles are "collapsed inwards". This means a drag handle that sits way on the edge of the screen is still fully visible and does not create horizontal scrollbars. 

No endgutters:

<img width="530" alt="Screenshot 2020-04-09 at 11 23 07" src="https://user-images.githubusercontent.com/1204802/78879702-8a0a6500-7a54-11ea-8a28-067ebfc16201.png">

Endgutters:

<img width="646" alt="Screenshot 2020-04-09 at 11 22 48" src="https://user-images.githubusercontent.com/1204802/78879710-8c6cbf00-7a54-11ea-9fe4-a4ba4e04cd5c.png">

There will be a situation where you are running 5.3 without the plugin and using no endgutters, where some blocks in the leftmost column have their side UI cut off. I think this is an acceptable edgecase to not optimize for anymore. 