### PR TITLE
Add new icons.

### DIFF
--- a/blocks/layout-grid/constants.scss
+++ b/blocks/layout-grid/constants.scss
@@ -10,11 +10,13 @@ $grid-gutter-medium: 16px;
 $grid-gutter-large: $grid-gutter;
 $grid-gutter-huge: 48px;
 $grid-gutter__background-offset: $grid-gutter / 2 + 1px;
-$padding-none: 0px;
-$padding-small: 8px;
-$padding-medium: 16px;
-$padding-large: 24px;
-$padding-huge: 48px;
+
+// These can be deprecated.
+$padding-none: $grid-gutter-none;
+$padding-small: $grid-gutter-small;
+$padding-medium: $grid-gutter-medium;
+$padding-large: $grid-gutter;
+$padding-huge: $grid-gutter-huge;
 
 // Standard Gutenberg Breakpoints
 $break-huge: 1440px;

--- a/blocks/layout-grid/editor.scss
+++ b/blocks/layout-grid/editor.scss
@@ -165,9 +165,10 @@
 		&::after {
 			width: 8px;
 			border: none;
-			border-radius: 2px;
+			border-radius: 0;
 			height: 24px;
-			top: calc(50% - 12px);
+			top: 50%;
+			transform: translateY(-50%);
 			right: calc(50% - 4px);
 		}
 

--- a/blocks/layout-grid/src/grid-overlay.scss
+++ b/blocks/layout-grid/src/grid-overlay.scss
@@ -33,36 +33,20 @@
 	// Lower the z-index so it's under the block borders.
 	z-index: 0;
 
-	/*
-	// Previous border-gutter indicator.
-	.wpcom-overlay-grid__column {
-		border-left: 1px solid transparent;
-		border-right: 1px solid transparent;
-		transition: border .4s ease;
-
-		.has-child-selected &,
-		.is-hovered &,
-		.is-selected & {
-			border-left: 1px solid #e2e4e7;
-			border-right: 1px solid #e2e4e7;
-		}
+	// Colorize for dark themes also.
+	color: rgba(0,0,0,0.03);
+	.is-dark-theme & {
+		color: rgba(255,255,255,0.15);
 	}
-	*/
 
 	// Solid gutter shading.
 	.wpcom-overlay-grid__column {
 		transition: border .4s ease;
-		color: rgba(0,0,0,0.03);
-
-		.is-dark-theme & {
-			color: rgba(255,255,255,0.15);
-		}
 
 		// Default gutter.
 		.has-child-selected &,
 		.is-hovered &,
 		.is-selected & {
-
 			box-shadow:
 			-($grid-gutter / 2) 0 0 0 currentColor,
 			($grid-gutter / 2) 0 0 0 currentColor;
@@ -73,7 +57,6 @@
 			.has-child-selected &,
 			.is-hovered &,
 			.is-selected & {
-	
 				box-shadow:
 				-1px 0 0 0 currentColor,
 				1px 0 0 0 currentColor;
@@ -85,7 +68,6 @@
 			.has-child-selected &,
 			.is-hovered &,
 			.is-selected & {
-	
 				box-shadow:
 				-($grid-gutter-small / 2) 0 0 0 currentColor,
 				($grid-gutter-small / 2) 0 0 0 currentColor;
@@ -97,7 +79,6 @@
 			.has-child-selected &,
 			.is-hovered &,
 			.is-selected & {
-	
 				box-shadow:
 				-($grid-gutter-medium / 2) 0 0 0 currentColor,
 				($grid-gutter-medium / 2) 0 0 0 currentColor;
@@ -109,7 +90,6 @@
 			.has-child-selected &,
 			.is-hovered &,
 			.is-selected & {
-	
 				box-shadow:
 				-($grid-gutter-huge / 2) 0 0 0 currentColor,
 				($grid-gutter-huge / 2) 0 0 0 currentColor;
@@ -118,36 +98,52 @@
 	}
 }
 
+// End gutters and gap.
+.wpcom-overlay-grid {
+	box-shadow:
+	inset -#{ $grid-gutter-large / 2 } 0 0 0 currentColor,
+	inset #{ $grid-gutter-large / 2 } 0 0 0 currentColor;
+}
+
 .wp-block-jetpack-layout-gutter__none .wpcom-overlay-grid {
 	grid-gap: $grid-gutter-none;
-	padding-left: $padding-none;
-	padding-right: $padding-none;
+	padding-left: $grid-gutter;
+	padding-right: $grid-gutter;
 }
 
 .wp-block-jetpack-layout-gutter__small .wpcom-overlay-grid {
 	grid-gap: $grid-gutter-small;
-	padding-left: $padding-small;
-	padding-right: $padding-small;
+	padding-left: $grid-gutter-small;
+	padding-right: $grid-gutter-small;
+
+	box-shadow:
+	inset -#{ $grid-gutter-small / 2 } 0 0 0 currentColor,
+	inset #{ $grid-gutter-small / 2 } 0 0 0 currentColor;
 }
 
 .wp-block-jetpack-layout-gutter__medium .wpcom-overlay-grid {
 	grid-gap: $grid-gutter-medium;
-	padding-left: $padding-medium;
-	padding-right: $padding-medium;
+	padding-left: $grid-gutter-medium;
+	padding-right: $grid-gutter-medium;
+
+	box-shadow:
+	inset -#{ $grid-gutter-medium / 2 } 0 0 0 currentColor,
+	inset #{ $grid-gutter-medium / 2 } 0 0 0 currentColor;
 }
 
 .wp-block-jetpack-layout-gutter__huge .wpcom-overlay-grid {
 	grid-gap: $grid-gutter-huge;
-	padding-left: $padding-huge;
-	padding-right: $padding-huge;
+	padding-left: $grid-gutter-huge;
+	padding-right: $grid-gutter-huge;
+
+	box-shadow:
+	inset -#{ $grid-gutter-huge / 2 } 0 0 0 currentColor,
+	inset #{ $grid-gutter-huge / 2 } 0 0 0 currentColor;
 }
 
 .wp-block-jetpack-layout-gutter__nowrap .wpcom-overlay-grid {
-	padding-left: $padding-none;
-	padding-right: $padding-none;
-}
+	padding-left: $grid-gutter-none;
+	padding-right: $grid-gutter-none;
 
-body.is-resizing .wpcom-overlay-grid .wpcom-overlay-grid__column {
-	border-left: 1px solid #e2e4e7;
-	border-right: 1px solid #e2e4e7;
+	box-shadow: none;
 }

--- a/blocks/layout-grid/src/grid-overlay.scss
+++ b/blocks/layout-grid/src/grid-overlay.scss
@@ -23,16 +23,18 @@
 	bottom: 0;
 	right: 0;
 	display: grid;
-	grid-gap: 24px;
+	grid-gap: $grid-gutter;
 	grid-template-columns: $grid-desktop;
 
 	// This padding adds end gutters.
-	padding-left: 24px;
-	padding-right: 24px;
+	padding-left: $grid-gutter;
+	padding-right: $grid-gutter;
 
 	// Lower the z-index so it's under the block borders.
 	z-index: 0;
 
+	/*
+	// Previous border-gutter indicator.
 	.wpcom-overlay-grid__column {
 		border-left: 1px solid transparent;
 		border-right: 1px solid transparent;
@@ -43,6 +45,75 @@
 		.is-selected & {
 			border-left: 1px solid #e2e4e7;
 			border-right: 1px solid #e2e4e7;
+		}
+	}
+	*/
+
+	// Solid gutter shading.
+	.wpcom-overlay-grid__column {
+		transition: border .4s ease;
+		color: rgba(0,0,0,0.03);
+
+		.is-dark-theme & {
+			color: rgba(255,255,255,0.15);
+		}
+
+		// Default gutter.
+		.has-child-selected &,
+		.is-hovered &,
+		.is-selected & {
+
+			box-shadow:
+			-($grid-gutter / 2) 0 0 0 currentColor,
+			($grid-gutter / 2) 0 0 0 currentColor;
+		}
+
+		// No gutter.
+		.wp-block-jetpack-layout-gutter__none & {
+			.has-child-selected &,
+			.is-hovered &,
+			.is-selected & {
+	
+				box-shadow:
+				-1px 0 0 0 currentColor,
+				1px 0 0 0 currentColor;
+			}
+		}
+
+		// Small gutter.
+		.wp-block-jetpack-layout-gutter__small & {
+			.has-child-selected &,
+			.is-hovered &,
+			.is-selected & {
+	
+				box-shadow:
+				-($grid-gutter-small / 2) 0 0 0 currentColor,
+				($grid-gutter-small / 2) 0 0 0 currentColor;
+			}
+		}
+
+		// Medium gutter.
+		.wp-block-jetpack-layout-gutter__medium & {
+			.has-child-selected &,
+			.is-hovered &,
+			.is-selected & {
+	
+				box-shadow:
+				-($grid-gutter-medium / 2) 0 0 0 currentColor,
+				($grid-gutter-medium / 2) 0 0 0 currentColor;
+			}
+		}
+		
+		// Huge gutter.
+		.wp-block-jetpack-layout-gutter__huge & {
+			.has-child-selected &,
+			.is-hovered &,
+			.is-selected & {
+	
+				box-shadow:
+				-($grid-gutter-huge / 2) 0 0 0 currentColor,
+				($grid-gutter-huge / 2) 0 0 0 currentColor;
+			}
 		}
 	}
 }

--- a/blocks/layout-grid/src/icons.js
+++ b/blocks/layout-grid/src/icons.js
@@ -9,7 +9,16 @@ export const GridIcon = () => (
 		width="24" height="24"
 		viewBox="0 0 24 24"
 	>
-		<Path d="M4 5v13h17V5H4zm10 2v9h-3V7h3zM6 7h3v9H6V7zm13 9h-3V7h3v9z" />
+		<Path d="M19 6H6c-1.1 0-2 .9-2 2v9c0 1.1.9 2 2 2h13c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-7.5 11.5H6c-.3 0-.5-.2-.5-.5V8c0-.3.2-.5.5-.5h5.5v10zm4 0H13v-10h2.5v10zm4-.5c0 .3-.2.5-.5.5h-2v-10h2c.3 0 .5.2.5.5v9z" />
+	</SVG>
+);
+
+export const GridColumnIcon = () => (
+	<SVG xmlns="http://www.w3.org/2000/svg"
+		width="24" height="24"
+		viewBox="0 0 24 24"
+	>
+		<Path d="M19 6H6c-1.1 0-2 .9-2 2v9c0 1.1.9 2 2 2h13c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zM5.5 17V8c0-.3.2-.5.5-.5h5.5v10H6c-.3 0-.5-.2-.5-.5zm14 0c0 .3-.2.5-.5.5h-2v-10h2c.3 0 .5.2.5.5v9z" />
 	</SVG>
 );
 

--- a/blocks/layout-grid/src/index.js
+++ b/blocks/layout-grid/src/index.js
@@ -13,7 +13,7 @@ import editGrid from './grid/edit';
 import saveGrid from './grid/save';
 import editColumn from './grid-column/edit';
 import saveColumn from './grid-column/save';
-import { GridIcon } from './icons';
+import { GridIcon, GridColumnIcon } from './icons';
 import { getSpanForDevice, getOffsetForDevice, DEVICE_BREAKPOINTS, MAX_COLUMNS } from './constants';
 
 function getColumnAttributes( total, breakpoints ) {
@@ -92,7 +92,7 @@ export function registerBlock() {
 	registerBlockType( 'jetpack/layout-grid-column', {
 		description: __( 'A column used inside a Layout Grid block.', 'layout-grid' ),
 		title: __( 'Column', 'layout-grid' ),
-		icon: GridIcon,
+		icon: GridColumnIcon,
 		category: 'layout',
 		parent: [ 'jetpack/layout-grid' ],
 		supports: {


### PR DESCRIPTION
This PR adds new icons for the grid block. Block itself:

<img width="421" alt="Screenshot 2020-04-09 at 15 09 42" src="https://user-images.githubusercontent.com/1204802/78898575-50e1ed00-7a74-11ea-95df-7af0e10df078.png">

A column:

<img width="474" alt="Screenshot 2020-04-09 at 15 10 15" src="https://user-images.githubusercontent.com/1204802/78898581-53dcdd80-7a74-11ea-81e8-56e93faa3efa.png">

For reference, here's the stock Columns icon:

<img width="375" alt="Screenshot 2020-04-09 at 15 04 55" src="https://user-images.githubusercontent.com/1204802/78898593-5808fb00-7a74-11ea-8e86-8e6765f8d518.png">
