### PR TITLE
Use wp_enqueue_scripts instead of wp_head

### DIFF
--- a/blocks/layout-grid/index.php
+++ b/blocks/layout-grid/index.php
@@ -16,7 +16,7 @@ add_action( 'init', function() {
 	wp_set_script_translations( 'jetpack/layout-grid', 'layout-grid' );
 } );
 
-add_action( 'wp_head', function() {
+add_action( 'wp_enqueue_scripts', function() {
 	wp_enqueue_style(
 		'wpcom-layout-grid-front',
 		plugins_url( 'front.css', __FILE__ ),


### PR DESCRIPTION
This should ensure the style appears in the head.

Fixes #64 