### PR TITLE
Fix old class names not clearing when changing grid layout

### DIFF
--- a/blocks/layout-grid/src/grid/edit.js
+++ b/blocks/layout-grid/src/grid/edit.js
@@ -398,6 +398,7 @@ export default compose( [
 			const blockCopy = createBlock( ownProps.name, {
 				...ownProps.attributes,
 				...columnValues,
+				className: removeGridClasses( ownProps.attributes.className ),
 			}, innerBlocks );
 
 			replaceBlock( clientId, blockCopy );


### PR DESCRIPTION
If you have a grid layout with non-default start and span values and then change the number of columns, the class names from the old layout bleed through to the new layout.

## To test broken behaviour

Without this PR, use this HTML to create a 2 column grid with offsets.

```
<!-- wp:jetpack/layout-grid {"column1DesktopSpan":5,"column1DesktopOffset":1,"column1TabletSpan":4,"column1MobileSpan":4,"column2DesktopSpan":4,"column2DesktopOffset":1,"column2TabletSpan":4,"column2MobileSpan":4,"column3DesktopOffset":2} -->
<div class="wp-block-jetpack-layout-grid alignfull column1-desktop-grid__span-5 column1-desktop-grid__start-2 column1-desktop-grid__row-1 column2-desktop-grid__span-4 column2-desktop-grid__start-8 column2-desktop-grid__row-1 column1-tablet-grid__span-4 column1-tablet-grid__row-1 column2-tablet-grid__span-4 column2-tablet-grid__start-5 column2-tablet-grid__row-1 column1-mobile-grid__span-4 column1-mobile-grid__row-1 column2-mobile-grid__span-4 column2-mobile-grid__row-2"><!-- wp:jetpack/layout-grid-column -->
<div class="wp-block-jetpack-layout-grid-column wp-block-jetpack-layout-grid__padding-none"><!-- wp:image {"sizeSlug":"large"} -->
<figure class="wp-block-image size-large"><img src="https://images.pexels.com/photos/3635300/pexels-photo-3635300.jpeg?cs=srgb&amp;dl=aerial-view-of-road-between-green-grass-field-3635300.jpg&amp;fm=jpg" alt=""/></figure>
<!-- /wp:image --></div>
<!-- /wp:jetpack/layout-grid-column -->

<!-- wp:jetpack/layout-grid-column -->
<div class="wp-block-jetpack-layout-grid-column wp-block-jetpack-layout-grid__padding-none"><!-- wp:image {"sizeSlug":"large"} -->
<figure class="wp-block-image size-large"><img src="https://images.pexels.com/photos/1103970/pexels-photo-1103970.jpeg?auto=compress&amp;cs=tinysrgb&amp;dpr=2&amp;h=750&amp;w=1260" alt=""/></figure>
<!-- /wp:image --></div>
<!-- /wp:jetpack/layout-grid-column --></div>
<!-- /wp:jetpack/layout-grid -->
```

![image](https://user-images.githubusercontent.com/1277682/80507134-66a94a80-896e-11ea-99be-a09812ca60bf.png)

Save the post, preview, and verify that the front end looks as expected.

Now change the number of columns to 3 and add an image to the 3rd column:

![image](https://user-images.githubusercontent.com/1277682/80507467-ca337800-896e-11ea-9c2f-fb2cd9cff6c8.png)

Save this and preview. Verify that the front end incorrectly shows overlapping images:

![image](https://user-images.githubusercontent.com/1277682/80507582-e3d4bf80-896e-11ea-9d0c-d0cc1d1a97d3.png)

## To test fixed behaviour

Apply PR, perform the same steps as above, but this time the front end should be correct:

![image](https://user-images.githubusercontent.com/1277682/80507909-475eed00-896f-11ea-9e44-914871aac338.png)


Fixes #65 
