### PR TITLE
Add a few small fixes.

### DIFF
--- a/blocks/layout-grid/editor.scss
+++ b/blocks/layout-grid/editor.scss
@@ -10,14 +10,20 @@
 // Unset many of the paddings and margins the block editor sets.
 // This is to make sure resizing the column containers works as expected.
 
-// 1. Reset margins on immediate innerblocks container.
+// 1. Reset margins on block itself, so it doesn't inherit the baseline margin.
+[data-type="jetpack/layout-grid"] {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+// 2. Reset margins on immediate innerblocks container.
 [data-type="jetpack/layout-grid"] > .block-editor-block-list__block-edit > [data-block] {
 	margin-top: 0;
 	margin-bottom: 0;
 }
 
+// 3. Unset margins and paddings for column container.
 [data-type="jetpack/layout-grid-column"].wp-block { // Selector needs specificity to override.
-	// 2. Unset margins and paddings for column container.
 	margin: 0;
 	padding-left: 0;
 	padding-right: 0;

--- a/blocks/layout-grid/style.scss
+++ b/blocks/layout-grid/style.scss
@@ -16,6 +16,9 @@
 	padding-left: 24px;
 	padding-right: 24px;
 
+	// This ensures those paddings work on the frontend.
+	box-sizing: border-box;
+
 	&.wp-block-jetpack-layout-gutter__none {
 		padding-left: $padding-none;
 		padding-right: $padding-none;


### PR DESCRIPTION
Extra vertical spacing is reported in Varia themes, that use this block a lot:

https://github.com/Automattic/themes/issues/1798

This is because in the editor, every single block, including block containers, has an intrinsic top and bottom margin.

This unsets that margin for the layout grid, making sure editor and frontend look the same:

<img width="626" alt="Screenshot 2020-05-07 at 14 55 59" src="https://user-images.githubusercontent.com/1204802/81298323-ed4bdf00-9074-11ea-96f5-5fdd87be8994.png">
<img width="523" alt="Screenshot 2020-05-07 at 14 56 02" src="https://user-images.githubusercontent.com/1204802/81298328-efae3900-9074-11ea-8c6f-b32ab6cb02b7.png">

It has a side-effect — this doesn't look great:

<img width="768" alt="Screenshot 2020-05-07 at 14 56 08" src="https://user-images.githubusercontent.com/1204802/81298369-fa68ce00-9074-11ea-9a62-54f8974bcbce.png">

However, it's still accurate! So in that vein I'm tempted to keep that as is. We _can_ make rules to space this out, but I lean towards not doing that. If you really want to insert multiple layout grids after each other, it feels correct to show that they will snug up against each other.

Finally, it fixes an issue where on some themes, the end-gutter option wouldn't work. Pictured below, end gutters not working:

![layout grid](https://user-images.githubusercontent.com/1204802/81298505-25532200-9075-11ea-8e66-511119256a4e.gif)

It works in this PR, rest assured.

I would not call a release of this urgent — fine to bundle it up with other patches that may need to be made. 