### PR TITLE
Fix layout-grid to only load CSS when needed

### DIFF
--- a/blocks/layout-grid/index.php
+++ b/blocks/layout-grid/index.php
@@ -3,21 +3,29 @@
 add_action( 'init', function() {
 	register_block_type( 'jetpack/layout-grid', [
 		'editor_script' => 'block-experiments',
-		'style' => 'block-experiments',
 		'editor_style' => 'block-experiments-editor',
+		'render_callback' => function( $attribs, $content ) {
+			wp_enqueue_style( 'jetpack-layout-grid' );
+			wp_enqueue_style( 'wpcom-layout-grid-front' );
+			return $content;
+		}
 	] );
 
 	register_block_type( 'jetpack/layout-grid-column', [
 		'editor_script' => 'block-experiments',
-		'style' => 'block-experiments',
 		'editor_style' => 'block-experiments-editor',
+		'render_callback' => function( $attribs, $content ) {
+			wp_enqueue_style( 'jetpack-layout-grid' );
+			wp_enqueue_style( 'wpcom-layout-grid-front' );
+			return $content;
+		}
 	] );
 
 	wp_set_script_translations( 'jetpack/layout-grid', 'layout-grid' );
 } );
 
-add_action( 'wp_enqueue_scripts', function() {
-	wp_enqueue_style(
+add_action( 'init', function() {
+	wp_register_style(
 		'wpcom-layout-grid-front',
 		plugins_url( 'front.css', __FILE__ ),
 		[], // no dependencies


### PR DESCRIPTION
The current layout grid plugin - https://wordpress.org/plugins/layout-grid/ -
will add the following to every page view as soon as it is activated:

- layout-grid/style.css 4 KB ( 562 bytes gz )
- layout-grid/blocks/front.css 61.8 KB ( 3.4 KB gz )

This addresses this problem by moving the addition of the CSS to be part of
the `render_callback` flow in `register_block_type`.