### PR TITLE
Fix gridlines

### DIFF
--- a/blocks/layout-grid/src/grid-overlay.scss
+++ b/blocks/layout-grid/src/grid-overlay.scss
@@ -12,9 +12,7 @@
 	// By being relative when unselected and absolute when selected, we
 	// constantly "refresh" this hack.
 	position: relative;
-	.is-hovered &,
-	.is-selected &,
-	.has-child-selected & {
+	.is-selected & {
 		position: absolute;
 	}
 
@@ -44,8 +42,6 @@
 		transition: border .4s ease;
 
 		// Default gutter.
-		.has-child-selected &,
-		.is-hovered &,
 		.is-selected & {
 			box-shadow:
 			-($grid-gutter / 2) 0 0 0 currentColor,
@@ -54,8 +50,6 @@
 
 		// No gutter.
 		.wp-block-jetpack-layout-gutter__none & {
-			.has-child-selected &,
-			.is-hovered &,
 			.is-selected & {
 				box-shadow:
 				-1px 0 0 0 currentColor,
@@ -65,8 +59,6 @@
 
 		// Small gutter.
 		.wp-block-jetpack-layout-gutter__small & {
-			.has-child-selected &,
-			.is-hovered &,
 			.is-selected & {
 				box-shadow:
 				-($grid-gutter-small / 2) 0 0 0 currentColor,
@@ -76,8 +68,6 @@
 
 		// Medium gutter.
 		.wp-block-jetpack-layout-gutter__medium & {
-			.has-child-selected &,
-			.is-hovered &,
 			.is-selected & {
 				box-shadow:
 				-($grid-gutter-medium / 2) 0 0 0 currentColor,
@@ -87,8 +77,6 @@
 		
 		// Huge gutter.
 		.wp-block-jetpack-layout-gutter__huge & {
-			.has-child-selected &,
-			.is-hovered &,
 			.is-selected & {
 				box-shadow:
 				-($grid-gutter-huge / 2) 0 0 0 currentColor,


### PR DESCRIPTION
Fixes #89. 

Previously, the gridlines were shown if you had selected the Layout Grid block, or any child.

After this PR, the gridlines are shown only if you have selected the Layout Grid block, not when a child is selected.

Before, Child:

<img width="901" alt="Screenshot 2020-06-08 at 11 37 43" src="https://user-images.githubusercontent.com/1204802/84015821-b40cd480-a97c-11ea-8940-d7dd0b7bbd6f.png">

After, Child:

<img width="922" alt="Screenshot 2020-06-08 at 11 37 52" src="https://user-images.githubusercontent.com/1204802/84015840-bc650f80-a97c-11ea-9dbd-32e33c564b5c.png">

After, parent:

<img width="953" alt="Screenshot 2020-06-08 at 11 37 56" src="https://user-images.githubusercontent.com/1204802/84015851-c0912d00-a97c-11ea-9776-f46fb986552d.png">

