### PR TITLE
Add vertical alignment to grid

### DIFF
--- a/blocks/layout-grid/editor.scss
+++ b/blocks/layout-grid/editor.scss
@@ -214,6 +214,18 @@
  * Individual column alignment for the editor
  */
 .wp-block-jetpack-layout-grid {
+	&.are-vertically-aligned-top [data-type="jetpack/layout-grid-column"].wp-block {
+		align-self: flex-start;
+	}
+
+	&.are-vertically-aligned-center [data-type="jetpack/layout-grid-column"].wp-block {
+		align-self: center;
+	}
+
+	&.are-vertically-aligned-bottom [data-type="jetpack/layout-grid-column"].wp-block {
+		align-self: flex-end;
+	}
+
 	// Note we add the alignment on the parent block as the editor nesting means it's not possible to affect the grid
 	@for $x from 1 through 4 {
 		&.column#{ $x }-grid__valign-top [data-type="jetpack/layout-grid-column"].wp-block:nth-child(#{ $x }) {

--- a/blocks/layout-grid/editor.scss
+++ b/blocks/layout-grid/editor.scss
@@ -209,3 +209,21 @@
 		}
 	}
 }
+
+/**
+ * Individual column alignment for the editor
+ */
+.wp-block-jetpack-layout-grid {
+	// Note we add the alignment on the parent block as the editor nesting means it's not possible to affect the grid
+	@for $x from 1 through 4 {
+		&.column#{ $x }-grid__valign-top [data-type="jetpack/layout-grid-column"].wp-block:nth-child(#{ $x }) {
+			align-self: flex-start;
+		}
+		&.column#{ $x }-grid__valign-center [data-type="jetpack/layout-grid-column"].wp-block:nth-child(#{ $x }) {
+			align-self: center;
+		}
+		&.column#{ $x }-grid__valign-bottom [data-type="jetpack/layout-grid-column"].wp-block:nth-child(#{ $x }) {
+			align-self: flex-end;
+		}
+	}
+}

--- a/blocks/layout-grid/index.php
+++ b/blocks/layout-grid/index.php
@@ -6,9 +6,10 @@ add_action( 'init', function() {
 		'editor_style' => 'block-experiments-editor',
 		'render_callback' => function( $attribs, $content ) {
 			wp_enqueue_style( 'jetpack-layout-grid' );
+			wp_enqueue_style( 'block-experiments' );
 			wp_enqueue_style( 'wpcom-layout-grid-front' );
 			return $content;
-		}
+		},
 	] );
 
 	register_block_type( 'jetpack/layout-grid-column', [
@@ -16,9 +17,10 @@ add_action( 'init', function() {
 		'editor_style' => 'block-experiments-editor',
 		'render_callback' => function( $attribs, $content ) {
 			wp_enqueue_style( 'jetpack-layout-grid' );
+			wp_enqueue_style( 'block-experiments' );
 			wp_enqueue_style( 'wpcom-layout-grid-front' );
 			return $content;
-		}
+		},
 	] );
 
 	wp_set_script_translations( 'jetpack/layout-grid', 'layout-grid' );

--- a/blocks/layout-grid/src/grid-column/save.js
+++ b/blocks/layout-grid/src/grid-column/save.js
@@ -16,12 +16,14 @@ const save = ( { attributes = {} } ) => {
 		backgroundColor,
 		customBackgroundColor,
 		padding,
+		verticalAlignment,
 	} = attributes;
 	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 	const classes = classnames( className, {
 		[ 'wp-block-jetpack-layout-grid__padding-' + padding ]: true,
 		'has-background': backgroundColor,
 		[ backgroundClass ]: backgroundClass,
+		[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
 	} );
 	const style = {
 		backgroundColor: backgroundClass ? undefined : customBackgroundColor,

--- a/blocks/layout-grid/src/grid/css-classname.js
+++ b/blocks/layout-grid/src/grid/css-classname.js
@@ -176,7 +176,9 @@ export function removeGridClasses( classes ) {
 		.replace( /column\d-\w*-grid__\w*-\d*/g, '' )
 		.replace( /column\d-grid__\w*-\d*/g, '' )
 		.replace( /\s{2,}/, '' )
-		.replace( /wp-block-jetpack-layout-gutter__\w*/, '' );
+		.replace( /wp-block-jetpack-layout-gutter__\w*/, '' )
+		.replace( /is-vertically-aligned-\w*/, '' )
+		.replace( /are-vertically-aligned-\w*/ );
 }
 
 export function getGutterClasses( { gutterSize, addGutterEnds } ) {

--- a/blocks/layout-grid/src/index.js
+++ b/blocks/layout-grid/src/index.js
@@ -83,6 +83,9 @@ export function registerBlock() {
 				type: 'boolean',
 				default: true,
 			},
+			verticalAlignment: {
+				type: 'string',
+			},
 			...getColumnAttributes( MAX_COLUMNS, DEVICE_BREAKPOINTS ),
 		},
 		edit: editGrid,
@@ -110,6 +113,9 @@ export function registerBlock() {
 			padding: {
 				type: 'string',
 				default: 'none',
+			},
+			verticalAlignment: {
+				type: 'string',
 			},
 		},
 		edit: editColumn,

--- a/blocks/layout-grid/style.scss
+++ b/blocks/layout-grid/style.scss
@@ -148,3 +148,38 @@
 		}
 	}
 }
+
+/**
+ * Parent column alignment
+ */
+.wp-block-jetpack-layout-grid {
+	&.are-vertically-aligned-top {
+		align-items: flex-start;
+	}
+
+	&.are-vertically-aligned-center {
+		align-items: center;
+	}
+
+	&.are-vertically-aligned-bottom {
+		align-items: flex-end;
+	}
+}
+
+/**
+ * Individual column alignment
+ */
+.wp-block-jetpack-layout-grid-column {
+	// These only affect the front end. The editor has specific CSS
+	&.is-vertically-aligned-top {
+		align-self: flex-start;
+	}
+
+	&.is-vertically-aligned-center {
+		align-self: center;
+	}
+
+	&.is-vertically-aligned-bottom {
+		align-self: flex-end;
+	}
+}

--- a/blocks/layout-grid/style.scss
+++ b/blocks/layout-grid/style.scss
@@ -170,7 +170,6 @@
  * Individual column alignment
  */
 .wp-block-jetpack-layout-grid-column {
-	// These only affect the front end. The editor has specific CSS
 	&.is-vertically-aligned-top {
 		align-self: flex-start;
 	}


### PR DESCRIPTION
Adds a vertical alignment button to the grid container, and the same to columns:

![image](https://user-images.githubusercontent.com/1277682/84263050-ae4af680-ab16-11ea-8896-471691b1ce77.png)

As with the columns block, changing the container alignment updates all columns. Changing a column only affects that column.

Top:

![image](https://user-images.githubusercontent.com/1277682/84263223-03870800-ab17-11ea-9079-f72202d35d14.png)

Centre:

![image](https://user-images.githubusercontent.com/1277682/84263237-0eda3380-ab17-11ea-869b-4dd1fd055493.png)

Bottom:

![image](https://user-images.githubusercontent.com/1277682/84263257-17326e80-ab17-11ea-92b9-4ecb04c1833e.png)

There is some difference between having top vertical alignment applied, and having no vertical alignment. With no alignment, a column fills the height:

![image](https://user-images.githubusercontent.com/1277682/84263306-2dd8c580-ab17-11ea-9e75-ab7d33698dd2.png)

With top alignment it doesn't fill height:

![image](https://user-images.githubusercontent.com/1277682/84263333-3df0a500-ab17-11ea-8cad-f8e6775b6e3d.png)

Fixes #52 