### PR TITLE
Fix loading of style.css inside the editor

### DIFF
--- a/blocks/layout-grid/index.php
+++ b/blocks/layout-grid/index.php
@@ -4,9 +4,9 @@
 add_action( 'init', function() {
 	register_block_type( 'jetpack/layout-grid', [
 		'editor_script' => 'block-experiments',
+		'style' => 'block-experiments',
 		'editor_style' => 'block-experiments-editor',
 		'render_callback' => function( $attribs, $content ) {
-			wp_enqueue_style( 'block-experiments' );
 			wp_enqueue_style( 'wpcom-layout-grid-front' );
 			return $content;
 		},
@@ -14,9 +14,9 @@ add_action( 'init', function() {
 
 	register_block_type( 'jetpack/layout-grid-column', [
 		'editor_script' => 'block-experiments',
+		'style' => 'block-experiments',
 		'editor_style' => 'block-experiments-editor',
 		'render_callback' => function( $attribs, $content ) {
-			wp_enqueue_style( 'block-experiments' );
 			wp_enqueue_style( 'wpcom-layout-grid-front' );
 			return $content;
 		},

--- a/bundler/resources/jetpack-layout-grid/readme.txt
+++ b/bundler/resources/jetpack-layout-grid/readme.txt
@@ -27,6 +27,12 @@ You can follow development, file an issue, suggest features, and view the source
 * Add vertical alignment to grid and grid columns
 * Mirror grid device breakpoint with editor preview breakpoint
 
+= 1.2.3 - 29th June 2020 =
+* Fix some styles not loading in the editor
+
+= 1.2.2 - 23rd June 2020 =
+* Fix the CSS loading fix from 1.2.1 so it uses wp_register_style
+
 = 1.2.1 - 10th June 2020 =
 * Fix block inserter to show inside a grid column
 * Fix vertical margin in editor so it better matches the display


### PR DESCRIPTION
The previous change to `render_callback` meant that `style.css` didn’t load inside the editor (no blocks are rendered).

Go back to using the normal `style` param when registering the block, and let Gutenberg decide when to load the style

Fixes #103 