### PR TITLE
Grid block - add back-compat for preview device

### DIFF
--- a/bundler/resources/jetpack-layout-grid/readme.txt
+++ b/bundler/resources/jetpack-layout-grid/readme.txt
@@ -23,9 +23,9 @@ You can follow development, file an issue, suggest features, and view the source
 
 == Changelog ==
 
-= 1.3 - 22nd June 2020 =
+= 1.3 - 6th July 2020 =
 * Add vertical alignment to grid and grid columns
-* Mirror grid device breakpoint with editor preview breakpoint
+* Mirror grid device breakpoint with editor preview breakpoint (requires WP 5.5 or Gutenberg plugin)
 
 = 1.2.3 - 29th June 2020 =
 * Fix some styles not loading in the editor


### PR DESCRIPTION
`__experimentalGetPreviewDeviceType` isn’t supported in WordPress 5.4.2, so restore the old state-based device type while allowing the Gutenberg plugin to use `__experimentalGetPreviewDeviceType`.

This should be removed once we drop support for WordPress 5.4.2.