### PR TITLE
Update blocks categories

### DIFF
--- a/blocks/_helpers.js
+++ b/blocks/_helpers.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { getCategories } from '@wordpress/blocks';
+
+/**
+ * Accepts an array of category names and returns the first one that
+ * exists in the categories returned by `getCategories`. This allows
+ * for a "graceful degradation" strategy to category names, where
+ * we just add the new category name as the first item in the array
+ * argument, and leave the old ones for environments where they still
+ * exist and are used.
+ *
+ * @example
+ * // Prefer passing the new category first in the array, followed by
+ * // older fallback categories. Considering the 'new' category is
+ * // registered:
+ * getCategoryWithFallbacks('new','old', 'older');
+ * => 'new'
+ *
+ * @param {string[]} requestedCategories - an array of categories.
+ * @return {string} the first category name found.
+ * @throws {Error} if the no categories could be found.
+ */
+export function getCategoryWithFallbacks( ...requestedCategories ) {
+	const knownCategories = getCategories();
+	for ( const requestedCategory of requestedCategories ) {
+		if (
+			knownCategories.some( ( { slug } ) => slug === requestedCategory )
+		) {
+			return requestedCategory;
+		}
+	}
+	throw new Error(
+		`Could not find a category from the provided list: ${ requestedCategories.join(
+			','
+		) }`
+	);
+}

--- a/blocks/layout-grid/src/index.js
+++ b/blocks/layout-grid/src/index.js
@@ -14,15 +14,26 @@ import saveGrid from './grid/save';
 import editColumn from './grid-column/edit';
 import saveColumn from './grid-column/save';
 import { GridIcon, GridColumnIcon } from './icons';
-import { getSpanForDevice, getOffsetForDevice, DEVICE_BREAKPOINTS, MAX_COLUMNS } from './constants';
+import {
+	getSpanForDevice,
+	getOffsetForDevice,
+	DEVICE_BREAKPOINTS,
+	MAX_COLUMNS,
+} from './constants';
+import { getCategoryWithFallbacks } from '../../_helpers';
 
 function getColumnAttributes( total, breakpoints ) {
 	const attributes = {};
 
 	for ( let index = 0; index < total; index++ ) {
 		breakpoints.map( ( breakpoint ) => {
-			attributes[ getSpanForDevice( index, breakpoint ) ] = { type: 'number' };
-			attributes[ getOffsetForDevice( index, breakpoint ) ] = { type: 'number', default: 0 };
+			attributes[ getSpanForDevice( index, breakpoint ) ] = {
+				type: 'number',
+			};
+			attributes[ getOffsetForDevice( index, breakpoint ) ] = {
+				type: 'number',
+				default: 0,
+			};
 		} );
 	}
 
@@ -32,9 +43,12 @@ function getColumnAttributes( total, breakpoints ) {
 export function registerBlock() {
 	registerBlockType( 'jetpack/layout-grid', {
 		title: __( 'Layout Grid', 'layout-grid' ),
-		description: __( 'Align blocks to a global grid, with support for responsive breakpoints.', 'layout-grid' ),
+		description: __(
+			'Align blocks to a global grid, with support for responsive breakpoints.',
+			'layout-grid'
+		),
 		icon: GridIcon,
-		category: 'layout',
+		category: getCategoryWithFallbacks( 'design', 'layout' ),
 		supports: {
 			align: [ 'full' ],
 			html: false,
@@ -51,7 +65,10 @@ export function registerBlock() {
 							name: 'core/paragraph',
 							attributes: {
 								customFontSize: 32,
-								content: __( '<strong>Snow Patrol</strong>', 'layout-grid' ),
+								content: __(
+									'<strong>Snow Patrol</strong>',
+									'layout-grid'
+								),
 								align: 'center',
 							},
 						},
@@ -63,7 +80,8 @@ export function registerBlock() {
 						{
 							name: 'core/image',
 							attributes: {
-								url: 'https://s.w.org/images/core/5.3/Windbuchencom.jpg',
+								url:
+									'https://s.w.org/images/core/5.3/Windbuchencom.jpg',
 							},
 						},
 					],
@@ -93,10 +111,13 @@ export function registerBlock() {
 	} );
 
 	registerBlockType( 'jetpack/layout-grid-column', {
-		description: __( 'A column used inside a Layout Grid block.', 'layout-grid' ),
+		description: __(
+			'A column used inside a Layout Grid block.',
+			'layout-grid'
+		),
 		title: __( 'Column', 'layout-grid' ),
 		icon: GridColumnIcon,
-		category: 'layout',
+		category: getCategoryWithFallbacks( 'design', 'layout' ),
 		parent: [ 'jetpack/layout-grid' ],
 		supports: {
 			inserter: false,

--- a/blocks/test/_helpers.test.js
+++ b/blocks/test/_helpers.test.js
@@ -1,0 +1,39 @@
+/**
+ * Internal dependencies
+ */
+import { getCategoryWithFallbacks } from '../_helpers';
+
+jest.mock( '@wordpress/blocks', () => ( {
+	getCategories: () => [ { slug: 'foobar' }, { slug: 'barfoo' } ],
+} ) );
+
+describe( 'getCategoryWithFallbacks', () => {
+	describe( 'single category passed', () => {
+		it( 'returns the category if it exists', () => {
+			expect( getCategoryWithFallbacks( 'foobar' ) ).toBe( 'foobar' );
+		} );
+		it( 'throws an error if it does not exist', () => {
+			expect( () => getCategoryWithFallbacks( 'nah' ) ).toThrow( /nah/ );
+		} );
+	} );
+
+	describe( 'multiple categories are passed', () => {
+		it( 'throws an error if none of the categories exist', () => {
+			expect( () =>
+				getCategoryWithFallbacks( 'nah', 'meh', 'wut', 'foo' )
+			).toThrow( /nah,meh,wut,foo/ );
+		} );
+
+		it( 'ignores all unexisting categories until it finds the *first one* that exists, then returns it', () => {
+			expect(
+				getCategoryWithFallbacks( 'foobar', 'meh', 'barfoo' )
+			).toBe( 'foobar' );
+			expect(
+				getCategoryWithFallbacks( 'nah', 'foobar', 'barfoo', 'foo' )
+			).toBe( 'foobar' );
+			expect( getCategoryWithFallbacks( 'nah', 'meh', 'foobar' ) ).toBe(
+				'foobar'
+			);
+		} );
+	} );
+} );

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "clean": "rm -rf ./build ./plugin",
     "lint": "npm run lint-js & npm run lint-php",
     "lint-js": "wp-scripts lint-js blocks",
-    "lint-php": "composer run lint"
+    "lint-php": "composer run lint",
+    "test": "wp-scripts test-unit-js"
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.10.1",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Update the category names for relevant blocks in `block-experiments`. 
-  Adds a helper function that is used to safely update category names while still supporting old environments

#### Related PRs
* Jetpack blocks: https://github.com/Automattic/jetpack/pull/16363
* FSE blocks (wp-calypso): https://github.com/Automattic/wp-calypso/pull/43670
* wpcom-blocks: https://github.com/Automattic/wpcom-blocks/pull/178

#### Testing instructions:

##### Atomated tests

* `yarn test`

##### To manually test the changes

1. Setup a local Wordpress instance (i.e by using `wp-env`)
2. Follow the instructions to build `block-experiments` in its README
3. Symlink or move it to the plugins folder of your WP instance
4. Activate the plugin
5. Profit

#### Categories

* [X] Keep `a8c/bauhaus-centenary` in `widgets`
- [X] Keep `a8c/event` in `widgets`
- [X] [Change](https://github.com/Automattic/block-experiments/pull/110/files#diff-264f12914f7ca9ea517358bfc96cedaeR51) `jetpack/layout-grid` from `layout` -> `design`
- [X] [Change](https://github.com/Automattic/block-experiments/pull/110/files#diff-264f12914f7ca9ea517358bfc96cedaeR120) `jetpack/layout-grid-column` from `layout` -> `design`
- [X] Keep `a8c/motion-background-container` in `widgets`
- [X] Keep `a8c/starscape` in `widgets`
- [X] Keep `a8c/waves` in `widgets`

~Note: If [this PR](https://github.com/WordPress/gutenberg/pull/23695) gets approved and merged, then I'll remove the helper function and tests from here (including the installation/configuration of jest).~