### PR TITLE
Layout Grid: Constrain max-width of inner blocks

### DIFF
--- a/blocks/layout-grid/front.css
+++ b/blocks/layout-grid/front.css
@@ -1043,3 +1043,6 @@
 @-moz-document url-prefix() {
   .wp-block-jetpack-layout-grid .wp-block-cover {
     max-height: 0; } }
+
+.wp-block-jetpack-layout-grid-column {
+  max-width: 100%; }

--- a/blocks/layout-grid/front.scss
+++ b/blocks/layout-grid/front.scss
@@ -131,3 +131,8 @@
 		}
 	}
 }
+
+// Ensure inner blocks with deliberate overflows are still constrained to column.
+.wp-block-jetpack-layout-grid-column {
+	max-width: 100%; 
+}

--- a/blocks/layout-grid/src/grid.scss
+++ b/blocks/layout-grid/src/grid.scss
@@ -24,7 +24,7 @@
 	}
 
 	.wp-block {
-		max-width: none;
+		max-width: 100%;
 	}
 
 	// Prevent long unbroken words from overflowing.


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/41040

#### Changes proposed in this Pull Request
* Updates CSS to prevent inner blocks such as the Slideshow block from breaking the layout grid.

Blocks such as the Slideshow will stretch to take up as much room as they can while the grid columns would stretch to accomodate their content. The result was a Slideshow and grid column hitting the browser limits.

#### Testing Instructions
1. Checkout this PR as a plugin in local dev site
2. Run `yarn start` in the PR's directory
3. Using Firefox, create a post, switch to code editor view and paste the code below 
_(Adds two column grid plus slideshow, you can edit slideshow to add images if you prefer)_
```
<!-- wp:jetpack/layout-grid {"column1DesktopSpan":6,"column1TabletSpan":4,"column1MobileSpan":4,"column2DesktopSpan":6,"column2TabletSpan":4,"column2MobileSpan":4,"className":"column1-desktop-grid__span-6 column1-desktop-grid__row-1 column2-desktop-grid__span-6 column2-desktop-grid__start-7 column2-desktop-grid__row-1 column1-tablet-grid__span-4 column1-tablet-grid__row-1 column2-tablet-grid__span-4 column2-tablet-grid__start-5 column2-tablet-grid__row-1 column1-mobile-grid__span-4 column1-mobile-grid__row-1 column2-mobile-grid__span-4 column2-mobile-grid__row-2"} -->
<div class="wp-block-jetpack-layout-grid alignfull column1-desktop-grid__span-6 column1-desktop-grid__row-1 column2-desktop-grid__span-6 column2-desktop-grid__start-7 column2-desktop-grid__row-1 column1-tablet-grid__span-4 column1-tablet-grid__row-1 column2-tablet-grid__span-4 column2-tablet-grid__start-5 column2-tablet-grid__row-1 column1-mobile-grid__span-4 column1-mobile-grid__row-1 column2-mobile-grid__span-4 column2-mobile-grid__row-2"><!-- wp:jetpack/layout-grid-column -->
<div class="wp-block-jetpack-layout-grid-column wp-block-jetpack-layout-grid__padding-none"><!-- wp:paragraph -->
<p>Two columns, both span 6 layout columns, i.e. 50% width each.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:jetpack/layout-grid-column -->

<!-- wp:jetpack/layout-grid-column -->
<div class="wp-block-jetpack-layout-grid-column wp-block-jetpack-layout-grid__padding-none"><!-- wp:jetpack/slideshow {"ids":[61,59],"sizeSlug":"large"} -->
<div class="wp-block-jetpack-slideshow aligncenter" data-effect="slide"><div class="wp-block-jetpack-slideshow_container swiper-container"><ul class="wp-block-jetpack-slideshow_swiper-wrapper swiper-wrapper"><li class="wp-block-jetpack-slideshow_slide swiper-slide"><figure><img alt="" class="wp-block-jetpack-slideshow_image wp-image-61" data-id="61" src="http://localhost:8888/wp-content/uploads/2020/07/5184599_031119-kgo-shutterstock-rain-img.jpg"/></figure></li><li class="wp-block-jetpack-slideshow_slide swiper-slide"><figure><img alt="" class="wp-block-jetpack-slideshow_image wp-image-59" data-id="59" src="http://localhost:8888/wp-content/uploads/2020/07/download.jpeg"/></figure></li></ul><a class="wp-block-jetpack-slideshow_button-prev swiper-button-prev swiper-button-white" role="button"></a><a class="wp-block-jetpack-slideshow_button-next swiper-button-next swiper-button-white" role="button"></a><a aria-label="Pause Slideshow" class="wp-block-jetpack-slideshow_button-pause" role="button"></a><div class="wp-block-jetpack-slideshow_pagination swiper-pagination swiper-pagination-white"></div></div></div>
<!-- /wp:jetpack/slideshow --></div>
<!-- /wp:jetpack/layout-grid-column --></div>
<!-- /wp:jetpack/layout-grid -->
```
4. Slideshow block should be contained within the grid
5. Save the post and view on the front end. Confirm Slideshow block and Layout Grid behave correctly.

#### Screenshots
Editor Before:
<img width="600" alt="Screen Shot 2020-07-09 at 1 46 44 pm" src="https://user-images.githubusercontent.com/60436221/86995487-81106780-c1ec-11ea-9637-2f6407fda69f.png">

Editor After:
<img width="600" alt="Screen Shot 2020-07-09 at 1 46 06 pm" src="https://user-images.githubusercontent.com/60436221/86995494-879edf00-c1ec-11ea-8468-0dcca9b1475d.png">

Frontend Before:
<img width="600" alt="Screen Shot 2020-07-09 at 1 48 00 pm" src="https://user-images.githubusercontent.com/60436221/86995528-a1d8bd00-c1ec-11ea-83aa-c59562edfae4.png">

Frontend After:
<img width="600" alt="Screen Shot 2020-07-09 at 1 47 37 pm" src="https://user-images.githubusercontent.com/60436221/86995539-a9986180-c1ec-11ea-93ad-45bbb6a00ed7.png">
