### PR TITLE
Adjust Starscape Heading

### DIFF
--- a/blocks/starscape/style.scss
+++ b/blocks/starscape/style.scss
@@ -21,6 +21,7 @@
 		z-index: 1;
 		width: 100%;
 		font-size: 84px;
+		line-height: 1.3;
 	}
 }
 


### PR DESCRIPTION
Adjusts the line height for the Starscape Block. The line height is now fixed at 1.3.

@pablohoneyhoney suggested making it bold by default, but there isn't any mechanism in the RichText component to provide default formats (https://github.com/WordPress/gutenberg/issues/23976). I could force the font-weight to be bold in the CSS, but that would override any RichText bold styles applied.

Before:

![Starscape before changes](https://user-images.githubusercontent.com/5129775/87607278-34c89a00-c6ba-11ea-8cb2-5d004a1aef5f.png)

After:

![Starscape after changes](https://user-images.githubusercontent.com/5129775/87609671-680e2780-c6c0-11ea-94ec-565cfff67b72.png)


