### PR TITLE
Pass the correct script handle for translations

### DIFF
--- a/blocks/bauhaus-centenary/index.php
+++ b/blocks/bauhaus-centenary/index.php
@@ -16,5 +16,5 @@ add_action( 'init', function() {
 		]
 	);
 
-	wp_set_script_translations( 'a8c/bauhaus-centenary', 'bauhaus-centenary' );
+	wp_set_script_translations( 'block-experiments', 'bauhaus-centenary' );
 } );

--- a/blocks/event/index.php
+++ b/blocks/event/index.php
@@ -7,5 +7,5 @@ add_action( 'init', function() {
 		'editor_style' => 'block-experiments-editor',
 	] );
 
-	wp_set_script_translations( 'a8c/event', 'event' );
+	wp_set_script_translations( 'block-experiments', 'event' );
 } );

--- a/blocks/layout-grid/index.php
+++ b/blocks/layout-grid/index.php
@@ -22,7 +22,7 @@ add_action( 'init', function() {
 		},
 	] );
 
-	wp_set_script_translations( 'jetpack/layout-grid', 'layout-grid' );
+	wp_set_script_translations( 'block-experiments', 'layout-grid' );
 } );
 
 add_action( 'wp_enqueue_scripts', function() {

--- a/blocks/starscape/index.php
+++ b/blocks/starscape/index.php
@@ -7,5 +7,5 @@ add_action( 'init', function() {
 		'editor_style' => 'block-experiments-editor',
 	] );
 
-	wp_set_script_translations( 'a8c/starscape', 'starscape' );
+	wp_set_script_translations( 'block-experiments', 'starscape' );
 } );


### PR DESCRIPTION
Fix translations by passing the script handle to wp_set_script_translations() rather than the block name.

In testing the Block Directory in non-english, I ran into these blocks not loading translations. Turned out it's passing the block slug rather than the script to localise.