### PR TITLE
Fix layout grid translations

### DIFF
--- a/blocks/layout-grid/src/grid.scss
+++ b/blocks/layout-grid/src/grid.scss
@@ -49,7 +49,7 @@
 }
 
 // Editor grid styles
-.wp-block-jetpack-layout-grid {
+.block-editor .wp-block-jetpack-layout-grid {
 	// These three rules are only necessary for Safari.
 	// Safari interprets percentages in CSS grid differently.
 	// Flex causes children to "stretch", fixing that interpretation.

--- a/bundler/template/index.php
+++ b/bundler/template/index.php
@@ -40,8 +40,6 @@ add_action( 'init', function() {
 		[],
 		filemtime( __DIR__ . '/editor.css' )
 	);
-
-	wp_set_script_translations( '[RESOURCE]', '[LOCALE]' );
 } );
 
 /**


### PR DESCRIPTION
The call to `wp_set_script_translations` is added by the block itself, and does not need to be in the plugin root.

Also increase the specificity of the layout grid editor CSS to avoid problems when embedding the editor outside of wp-admin 