### PR TITLE
Fix deselect color error

### DIFF
--- a/blocks/waves/src/edit.js
+++ b/blocks/waves/src/edit.js
@@ -243,7 +243,7 @@ function Edit( { attributes, className, isSelected, setAttributes } ) {
 						{
 							label: __( 'Color 1', 'waves' ),
 							value: colors.color1,
-							onChange: ( color1 ) => {
+							onChange: ( color1 = colors.color1 ) => {
 								const previewImage = updatePreview( {
 									color1: parseColor( color1 ),
 								} );
@@ -253,7 +253,7 @@ function Edit( { attributes, className, isSelected, setAttributes } ) {
 						{
 							label: __( 'Color 2', 'waves' ),
 							value: colors.color2,
-							onChange: ( color2 ) => {
+							onChange: ( color2 = colors.color2 ) => {
 								const previewImage = updatePreview( {
 									color2: parseColor( color2 ),
 								} );
@@ -263,7 +263,7 @@ function Edit( { attributes, className, isSelected, setAttributes } ) {
 						{
 							label: __( 'Color 3', 'waves' ),
 							value: colors.color3,
-							onChange: ( color3 ) => {
+							onChange: ( color3 = colors.color3 ) => {
 								const previewImage = updatePreview( {
 									color3: parseColor( color3 ),
 								} );
@@ -273,7 +273,7 @@ function Edit( { attributes, className, isSelected, setAttributes } ) {
 						{
 							label: __( 'Color 4', 'waves' ),
 							value: colors.color4,
-							onChange: ( color4 ) => {
+							onChange: ( color4 = colors.color4 ) => {
 								const previewImage = updatePreview( {
 									color4: parseColor( color4 ),
 								} );

--- a/blocks/waves/waves.js
+++ b/blocks/waves/waves.js
@@ -17,13 +17,20 @@
 				.querySelectorAll( '.wp-block-a8c-waves canvas' )
 				.forEach( ( canvas ) => {
 					const dataset = {
-						color1: parseColor( dataset.color1 ),
-						color2: parseColor( dataset.color2 ),
-						color3: parseColor( dataset.color3 ),
-						color4: parseColor( dataset.color4 ),
-						complexity: Number.parseInt( dataset.complexity, 10 ),
-						mouseSpeed: Number.parseFloat( dataset.mouseSpeed ),
-						fluidSpeed: Number.parseFloat( dataset.fluidSpeed ),
+						color1: parseColor( canvas.dataset.color1 ),
+						color2: parseColor( canvas.dataset.color2 ),
+						color3: parseColor( canvas.dataset.color3 ),
+						color4: parseColor( canvas.dataset.color4 ),
+						complexity: Number.parseInt(
+							canvas.dataset.complexity,
+							10
+						),
+						mouseSpeed: Number.parseFloat(
+							canvas.dataset.mouseSpeed
+						),
+						fluidSpeed: Number.parseFloat(
+							canvas.dataset.fluidSpeed
+						),
 					};
 					run( canvas, dataset );
 				} );


### PR DESCRIPTION
Fixes #114 

Selecting an already selected color usually unsets the color to allow it to go back to the default setting. Since default settings are dynamic for the waves block colors, the behavior has been changed to just reselect the color instead or unsetting it.

I also included a bit of a performance tweak. Parsing the canvas dataset is now done outside of the render loop, since it only needs to happen when the color changes.