### PR TITLE
Release waves@1.0.1

### DIFF
--- a/blocks/waves/src/edit.js
+++ b/blocks/waves/src/edit.js
@@ -23,8 +23,6 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-const { run, parseColor, renderPreview } = window.a8cColorEffects;
-
 const DEFAULT_COLORS = {
 	color1: '#000',
 	color2: '#555',
@@ -104,6 +102,8 @@ function HeightInput( { onChange, onUnitChange, unit = 'px', value = '' } ) {
 }
 
 function Edit( { attributes, className, isSelected, setAttributes } ) {
+	const { run, parseColor, renderPreview } = window.a8cColorEffects;
+
 	const { toggleSelection } = useDispatch( 'core/block-editor' );
 	const [ temporaryMinHeight, setTemporaryMinHeight ] = useState( null );
 	const [ isResizing, setIsResizing ] = useState( false );

--- a/bundler/bundles/waves.json
+++ b/bundler/bundles/waves.json
@@ -1,6 +1,6 @@
 {
 	"blocks": [ "waves" ],
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"name": "Waves Block",
 	"description": "Blocks can now be sinuous and soothing with the Waves Block.",
 	"resource": "a8c-waves"

--- a/bundler/resources/a8c-waves/readme.txt
+++ b/bundler/resources/a8c-waves/readme.txt
@@ -1,7 +1,7 @@
 === Waves Block ===
 Contributors: automattic, ajlende, pablohoneyhoney
-Stable tag: 1.0.0
-Tested up to: 5.4.1
+Stable tag: 1.0.1
+Tested up to: 5.5
 Requires at least: 5.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -29,6 +29,10 @@ You can follow development, file an issue, suggest features, and view the source
 5. Enjoy the soothing animation.
 
 == Changelog ==
+
+= 1.0.1 - 3rd August 2020 =
+* Fix error when double selecting a color
+* Minor performance improvements
 
 = 1.0.0 - 22nd May 2020 =
 * Initial release


### PR DESCRIPTION
Fixes an error when running the bundled waves block and bumps the version to 1.0.1.