### PR TITLE
Update tested with versions for starscape and bauhaus

### DIFF
--- a/bundler/resources/a8c-bauhaus-centenary/readme.txt
+++ b/bundler/resources/a8c-bauhaus-centenary/readme.txt
@@ -1,7 +1,7 @@
 === Bauhaus Centenary Block ===
 Contributors: automattic, ajlende, pablohoneyhoney
-Stable tag: 1.0.1
-Tested up to: 5.3
+Stable tag: 1.0.2
+Tested up to: 5.5
 Requires at least: 5.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/bundler/resources/a8c-starscape/readme.txt
+++ b/bundler/resources/a8c-starscape/readme.txt
@@ -1,7 +1,7 @@
 === Starscape Block ===
 Contributors: automattic, ajlende, pablohoneyhoney
 Stable tag: 1.0.2
-Tested up to: 5.3.2
+Tested up to: 5.5
 Requires at least: 5.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Tested bauhaus and starscape with the 5.5 release candidate. Both worked without modification, so updated tested with version to 5.5.