### PR TITLE
Add mobile gutenberg editor support

### DIFF
--- a/blocks/layout-grid/src/grid-column/edit.native.js
+++ b/blocks/layout-grid/src/grid-column/edit.native.js
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import { View, AccessibilityInfo, Platform, Text } from 'react-native';
+import { times } from 'lodash';
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+
+import {
+	InnerBlocks,
+	InspectorControls,
+} from '@wordpress/block-editor';
+import { Component, createRef } from '@wordpress/element';
+import {
+	BlockControls,
+	BlockVerticalAlignmentToolbar,
+} from '@wordpress/block-editor';
+import {
+	PanelBody,
+	TextControl,
+	ButtonGroup,
+	Button,
+	IconButton,
+	Placeholder,
+	IsolatedEventContainer,
+	ToggleControl,
+	SelectControl,
+	Disabled,
+	ToolbarGroup,
+	MenuGroup,
+	MenuItem,
+	Dropdown,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { ENTER, SPACE } from '@wordpress/keycodes';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+import { createBlock } from '@wordpress/blocks';
+
+
+/**
+ * Internal dependencies
+ */
+import ColumnIcon from '../icons';
+import { getLayouts } from '../constants';
+
+const ALLOWED_BLOCKS = [ 'jetpack/layout-grid-column' ];
+
+class Edit extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.overlayRef = createRef();
+		this.state = {
+			selectedDevice: getLayouts()[ 0 ].value,
+		};
+    }
+
+    render() {
+        const {
+			className,
+			hasChildBlocks,
+			backgroundColor,
+			setBackgroundColor,
+			attributes,
+			setAttributes,
+			updateAlignment,
+        } = this.props;
+        
+        return <View>
+            <InnerBlocks
+					templateLock={ false }
+					renderAppender={ hasChildBlocks
+						? undefined
+						: () => <InnerBlocks.ButtonBlockAppender />
+					}
+				/>
+        </View>;
+    }
+}
+
+export default Edit;

--- a/blocks/layout-grid/src/grid-column/edit.native.js
+++ b/blocks/layout-grid/src/grid-column/edit.native.js
@@ -1,52 +1,13 @@
 /**
  * External dependencies
  */
-import { View, AccessibilityInfo, Platform, Text } from 'react-native';
-import { times } from 'lodash';
-import classnames from 'classnames';
+import { View } from 'react-native';
 
 /**
  * WordPress dependencies
  */
-
-import {
-	InnerBlocks
-} from '@wordpress/block-editor';
-import { Component, createRef } from '@wordpress/element';
-import {
-	BlockControls,
-	BlockVerticalAlignmentToolbar,
-} from '@wordpress/block-editor';
-import {
-	PanelBody,
-	TextControl,
-	ButtonGroup,
-	Button,
-	IconButton,
-	Placeholder,
-	IsolatedEventContainer,
-	ToggleControl,
-	SelectControl,
-	Disabled,
-	ToolbarGroup,
-	MenuGroup,
-	MenuItem,
-	Dropdown,
-} from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { ENTER, SPACE } from '@wordpress/keycodes';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
-import { createBlock } from '@wordpress/blocks';
-
-
-/**
- * Internal dependencies
- */
-import ColumnIcon from '../icons';
-import { getLayouts } from '../constants';
-
-const ALLOWED_BLOCKS = [ 'jetpack/layout-grid-column' ];
+import { InnerBlocks } from '@wordpress/block-editor';
+import { Component } from '@wordpress/element';
 
 class Edit extends Component {
 	constructor( props ) {

--- a/blocks/layout-grid/src/grid-column/edit.native.js
+++ b/blocks/layout-grid/src/grid-column/edit.native.js
@@ -10,8 +10,7 @@ import classnames from 'classnames';
  */
 
 import {
-	InnerBlocks,
-	InspectorControls,
+	InnerBlocks
 } from '@wordpress/block-editor';
 import { Component, createRef } from '@wordpress/element';
 import {
@@ -55,11 +54,14 @@ class Edit extends Component {
     }
 
     render() {
-      
+	
         return <View>
             <InnerBlocks
 					templateLock={ false }
-					renderAppender={ <InnerBlocks.ButtonBlockAppender /> }
+					renderAppender={ this.props.hasChildBlocks
+						? undefined
+						: () => <InnerBlocks.ButtonBlockAppender />
+					}
 				/>
         </View>;
     }

--- a/blocks/layout-grid/src/grid-column/edit.native.js
+++ b/blocks/layout-grid/src/grid-column/edit.native.js
@@ -12,20 +12,21 @@ import { Component } from '@wordpress/element';
 class Edit extends Component {
 	constructor( props ) {
 		super( props );
-    }
+	}
 
-    render() {
-	
-        return <View>
-            <InnerBlocks
-					templateLock={ false }
-					renderAppender={ this.props.hasChildBlocks
-						? undefined
-						: () => <InnerBlocks.ButtonBlockAppender />
-					}
-				/>
-        </View>;
-    }
+	render() {
+		return (
+		<View>
+			<InnerBlocks
+				templateLock={ false }
+				renderAppender={ this.props.hasChildBlocks
+					? undefined
+					: () => <InnerBlocks.ButtonBlockAppender />
+				}
+			/>
+		</View>
+		);
+	}
 }
 
 export default Edit;

--- a/blocks/layout-grid/src/grid-column/edit.native.js
+++ b/blocks/layout-grid/src/grid-column/edit.native.js
@@ -52,31 +52,14 @@ const ALLOWED_BLOCKS = [ 'jetpack/layout-grid-column' ];
 class Edit extends Component {
 	constructor( props ) {
 		super( props );
-
-		this.overlayRef = createRef();
-		this.state = {
-			selectedDevice: getLayouts()[ 0 ].value,
-		};
     }
 
     render() {
-        const {
-			className,
-			hasChildBlocks,
-			backgroundColor,
-			setBackgroundColor,
-			attributes,
-			setAttributes,
-			updateAlignment,
-        } = this.props;
-        
+      
         return <View>
             <InnerBlocks
 					templateLock={ false }
-					renderAppender={ hasChildBlocks
-						? undefined
-						: () => <InnerBlocks.ButtonBlockAppender />
-					}
+					renderAppender={ <InnerBlocks.ButtonBlockAppender /> }
 				/>
         </View>;
     }

--- a/blocks/layout-grid/src/grid-column/edit.native.js
+++ b/blocks/layout-grid/src/grid-column/edit.native.js
@@ -16,15 +16,15 @@ class Edit extends Component {
 
 	render() {
 		return (
-		<View>
-			<InnerBlocks
-				templateLock={ false }
-				renderAppender={ this.props.hasChildBlocks
-					? undefined
-					: () => <InnerBlocks.ButtonBlockAppender />
-				}
-			/>
-		</View>
+			<View>
+				<InnerBlocks
+					templateLock={ false }
+					renderAppender={ this.props.hasChildBlocks
+						? undefined
+						: () => <InnerBlocks.ButtonBlockAppender />
+					}
+				/>
+			</View>
 		);
 	}
 }

--- a/blocks/layout-grid/src/grid/edit.native.js
+++ b/blocks/layout-grid/src/grid/edit.native.js
@@ -52,11 +52,6 @@ const ALLOWED_BLOCKS = [ 'jetpack/layout-grid-column' ];
 class Edit extends Component {
 	constructor( props ) {
 		super( props );
-
-		this.overlayRef = createRef();
-		this.state = {
-			selectedDevice: getLayouts()[ 0 ].value,
-		};
     }
 
     render() {

--- a/blocks/layout-grid/src/grid/edit.native.js
+++ b/blocks/layout-grid/src/grid/edit.native.js
@@ -1,52 +1,19 @@
 /**
  * External dependencies
  */
-import { View, AccessibilityInfo, Platform, Text } from 'react-native';
-import { times } from 'lodash';
-import classnames from 'classnames';
+import { View } from 'react-native';
 
 /**
  * WordPress dependencies
  */
 
-import {
-	InnerBlocks,
-	InspectorControls,
-} from '@wordpress/block-editor';
-import { Component, createRef } from '@wordpress/element';
-import {
-	BlockControls,
-	BlockVerticalAlignmentToolbar,
-} from '@wordpress/block-editor';
-import {
-	PanelBody,
-	TextControl,
-	ButtonGroup,
-	Button,
-	IconButton,
-	Placeholder,
-	IsolatedEventContainer,
-	ToggleControl,
-	SelectControl,
-	Disabled,
-	ToolbarGroup,
-	MenuGroup,
-	MenuItem,
-	Dropdown,
-} from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { ENTER, SPACE } from '@wordpress/keycodes';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
-import { createBlock } from '@wordpress/blocks';
+import { InnerBlocks } from '@wordpress/block-editor';
+import { Component } from '@wordpress/element';
 
 
 /**
  * Internal dependencies
  */
-import ColumnIcon from '../icons';
-import { getLayouts } from '../constants';
-
 const ALLOWED_BLOCKS = [ 'jetpack/layout-grid-column' ];
 
 class Edit extends Component {

--- a/blocks/layout-grid/src/grid/edit.native.js
+++ b/blocks/layout-grid/src/grid/edit.native.js
@@ -6,13 +6,9 @@ import { View } from 'react-native';
 /**
  * WordPress dependencies
  */
-
 import { InnerBlocks } from '@wordpress/block-editor';
 import { Component } from '@wordpress/element';
 
-/**
- * Internal dependencies
- */
 const ALLOWED_BLOCKS = [ 'jetpack/layout-grid-column' ];
 
 const TEMPLATE = [
@@ -23,17 +19,17 @@ const TEMPLATE = [
 class Edit extends Component {
 	constructor( props ) {
 		super( props );
-    }
+	}
 
-    render() {
-        return <View>
-            <InnerBlocks
-                template={ TEMPLATE }
-                templateLock="all"
-                allowedBlocks={ ALLOWED_BLOCKS }
-            />
-        </View>;
-    }
+	render() {
+		return <View>
+				<InnerBlocks
+					template={ TEMPLATE }
+					templateLock="all"
+					allowedBlocks={ ALLOWED_BLOCKS }
+				/>
+		</View>;
+	}
 }
 
 export default Edit;

--- a/blocks/layout-grid/src/grid/edit.native.js
+++ b/blocks/layout-grid/src/grid/edit.native.js
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import { View, AccessibilityInfo, Platform, Text } from 'react-native';
+import { times } from 'lodash';
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+
+import {
+	InnerBlocks,
+	InspectorControls,
+} from '@wordpress/block-editor';
+import { Component, createRef } from '@wordpress/element';
+import {
+	BlockControls,
+	BlockVerticalAlignmentToolbar,
+} from '@wordpress/block-editor';
+import {
+	PanelBody,
+	TextControl,
+	ButtonGroup,
+	Button,
+	IconButton,
+	Placeholder,
+	IsolatedEventContainer,
+	ToggleControl,
+	SelectControl,
+	Disabled,
+	ToolbarGroup,
+	MenuGroup,
+	MenuItem,
+	Dropdown,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { ENTER, SPACE } from '@wordpress/keycodes';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+import { createBlock } from '@wordpress/blocks';
+
+
+/**
+ * Internal dependencies
+ */
+import ColumnIcon from '../icons';
+import { getLayouts } from '../constants';
+
+const ALLOWED_BLOCKS = [ 'jetpack/layout-grid-column' ];
+
+class Edit extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.overlayRef = createRef();
+		this.state = {
+			selectedDevice: getLayouts()[ 0 ].value,
+		};
+    }
+
+    render() {
+        return <View>
+            <InnerBlocks
+                template={ null }
+                templateLock="all"
+                allowedBlocks={ ALLOWED_BLOCKS }
+            />
+        </View>;
+    }
+}
+
+export default Edit;

--- a/blocks/layout-grid/src/grid/edit.native.js
+++ b/blocks/layout-grid/src/grid/edit.native.js
@@ -10,11 +10,15 @@ import { View } from 'react-native';
 import { InnerBlocks } from '@wordpress/block-editor';
 import { Component } from '@wordpress/element';
 
-
 /**
  * Internal dependencies
  */
 const ALLOWED_BLOCKS = [ 'jetpack/layout-grid-column' ];
+
+const TEMPLATE = [
+	[ 'jetpack/layout-grid-column', {}, [] ],
+	[ 'jetpack/layout-grid-column', {}, [] ],
+];
 
 class Edit extends Component {
 	constructor( props ) {
@@ -24,7 +28,7 @@ class Edit extends Component {
     render() {
         return <View>
             <InnerBlocks
-                template={ null }
+                template={ TEMPLATE }
                 templateLock="all"
                 allowedBlocks={ ALLOWED_BLOCKS }
             />

--- a/blocks/layout-grid/src/grid/layout-grid/index.js
+++ b/blocks/layout-grid/src/grid/layout-grid/index.js
@@ -229,7 +229,7 @@ class LayoutGrid {
 			return start;
 		}
 
-		const currentStart = this.getStart( column );  // This is the current start
+		const currentStart = this.getStart( column ); // This is the current start
 		const diff = start - currentStart;
 
 		return this.getOffset( column ) + diff;


### PR DESCRIPTION
This PR is part of an effort to add the layout-grid block to the mobile gutenberg editor. 

For more info see:
Mobile Gutenberg PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2582

- Adds the simple read only version of the layout-grid and layout-grid-column blocks to the mobile gutenberg editor.

Since the newly added `*.native.js` files are not included anywhere build process. I don't expect that they will have any influence on the build of the wordpress plugin. 

