### PR TITLE
Mobile: Add gutter settings

### DIFF
--- a/blocks/layout-grid/src/grid/edit.native.js
+++ b/blocks/layout-grid/src/grid/edit.native.js
@@ -7,13 +7,26 @@ import { delay, flatMap } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { InnerBlocks, BlockVariationPicker } from '@wordpress/block-editor';
-
+import { 
+	InnerBlocks,
+	InspectorControls,
+	BlockVariationPicker,
+ } from '@wordpress/block-editor';
+ import {
+	PanelBody,
+	SelectControl,
+	ToggleControl,
+	FooterMessageControl,
+	Disabled,
+} from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
 import variations from './variations';
+import { getGutterValues } from './../constants';
+
 
 const ALLOWED_BLOCKS = [ 'jetpack/layout-grid-column' ];
 
@@ -23,9 +36,11 @@ const TEMPLATE = [
 ];
 
 const Edit = ( props ) => {
-	const { clientId, isSelected } = props;
+	const { clientId, isSelected, setAttributes, attributes = {} } = props;
 	const [ isVisible, setIsVisible ] = useState( false );
 	const isDefaultColumns = true;
+
+	const { gutterSize, addGutterEnds, verticalAlignment } = attributes;
 
 	useEffect( () => {
 		if ( isSelected && isDefaultColumns ) {
@@ -33,6 +48,17 @@ const Edit = ( props ) => {
 		}
 	}, [] );
 
+	const toggleControl = (
+		<ToggleControl
+			label={ __( 'Add end gutters', 'layout-grid' ) }
+			help={
+				addGutterEnds ? __( 'Toggle off to remove the spacing left and right of the grid.', 'layout-grid' ) : __( 'Toggle on to add space left and right of the layout grid. ', 'layout-grid' )
+			}
+			checked={ addGutterEnds }
+			onChange={ newValue => setAttributes( { addGutterEnds: newValue } )  }
+		/>
+	);
+	
 	return (
 		<>
 			<View>
@@ -42,6 +68,29 @@ const Edit = ( props ) => {
 					allowedBlocks={ ALLOWED_BLOCKS }
 				/>
 			</View>
+			<InspectorControls>
+				<PanelBody title={ __( 'Layout grid settings' ) }>
+				<SelectControl
+					label={ __( 'Gutters' ) }
+					value={ gutterSize }
+					// `undefined` is required for the preload attribute to be unset.
+					onChange={  newValue => setAttributes( { gutterSize: newValue, addGutterEnds: newValue === 'none' ? false : addGutterEnds } ) }
+					options={ getGutterValues() }
+				/>
+				{ gutterSize === 'none' ? (
+					<Disabled>
+						{ toggleControl }
+					</Disabled>
+				) : toggleControl }
+				</PanelBody>
+				<PanelBody>
+					<FooterMessageControl
+						label={ __(
+							'Note: Column layout may vary between themes and screen sizes'
+						) }
+					/>
+				</PanelBody>
+			</InspectorControls>
 			<BlockVariationPicker
 				variations={ variations }
 				onClose={ () => setIsVisible( false ) }


### PR DESCRIPTION
Adds gutter settings to the mobile view inspector controls. 

This PR continuous from https://github.com/Automattic/block-experiments/pull/139 and add the gutter settings. 

- It currently doesn't change the gutters on block UI level but just adds the settings. 

See:
_iOS:_
![Screen Shot 2020-09-04 at 1 59 15 PM](https://user-images.githubusercontent.com/115071/92289856-e324da80-eec6-11ea-8a29-224ce58c7e40.png)
![Screen Shot 2020-09-04 at 1 59 19 PM](https://user-images.githubusercontent.com/115071/92289855-e28c4400-eec6-11ea-8fd0-e10c1ebe7f08.png)

_Android:_
![Screen Shot 2020-09-04 at 2 01 32 PM](https://user-images.githubusercontent.com/115071/92289854-e1f3ad80-eec6-11ea-91a9-d2e55461e609.png)
![Screen Shot 2020-09-04 at 2 01 41 PM](https://user-images.githubusercontent.com/115071/92289853-e029ea00-eec6-11ea-9279-8ec1927baf40.png)



**To test:**
Follow the steps in wordpress-mobile/gutenberg-mobile#2582

Then navigate to block-experiments directory
cd block-experiments and switch the repository to this branch.

Reload the Demo app.