### PR TITLE
Fix issue with layout inconsistency.

### DIFF
--- a/blocks/layout-grid/style.scss
+++ b/blocks/layout-grid/style.scss
@@ -113,6 +113,9 @@
 
 		&.has-background {
 			padding: $padding-none ($padding-none + $grid-gutter__background-offset);
+
+			// Needs a max-width in order to constrain contents.
+			max-width: calc( 100% + #{ ($padding-none + $grid-gutter__background-offset) * 2 } );
 		}
 	}
 
@@ -121,6 +124,9 @@
 
 		&.has-background {
 			padding: $padding-small ($padding-small + $grid-gutter__background-offset);
+
+			// Needs a max-width in order to constrain contents.
+			max-width: calc( 100% + #{ ($padding-small + $grid-gutter__background-offset) * 2 } );
 		}
 	}
 
@@ -129,6 +135,9 @@
 
 		&.has-background {
 			padding: $padding-medium ($padding-medium + $grid-gutter__background-offset);
+
+			// Needs a max-width in order to constrain contents.
+			max-width: calc( 100% + #{ ($padding-medium + $grid-gutter__background-offset) * 2 } );
 		}
 	}
 
@@ -137,6 +146,9 @@
 
 		&.has-background {
 			padding: $padding-large ($padding-large + $grid-gutter__background-offset);
+
+			// Needs a max-width in order to constrain contents.
+			max-width: calc( 100% + #{ ($padding-large + $grid-gutter__background-offset) * 2 } );
 		}
 	}
 
@@ -145,6 +157,9 @@
 
 		&.has-background {
 			padding: $padding-huge ($padding-huge + $grid-gutter__background-offset);
+
+			// Needs a max-width in order to constrain contents.
+			max-width: calc( 100% + #{ ($padding-huge + $grid-gutter__background-offset) * 2 } );
 		}
 	}
 }

--- a/blocks/layout-grid/tests/tools/style.css
+++ b/blocks/layout-grid/tests/tools/style.css
@@ -28,23 +28,28 @@
   .wp-block-jetpack-layout-grid.wp-block-jetpack-layout-grid__padding-none {
     padding: 0px; }
     .wp-block-jetpack-layout-grid.wp-block-jetpack-layout-grid__padding-none.has-background {
-      padding: 0px 13px; }
+      padding: 0px 13px;
+      max-width: calc( 100% + 0px); }
   .wp-block-jetpack-layout-grid.wp-block-jetpack-layout-grid__padding-small .wp-block-jetpack-layout-grid-column {
     padding: 8px; }
     .wp-block-jetpack-layout-grid.wp-block-jetpack-layout-grid__padding-small .wp-block-jetpack-layout-grid-column.has-background {
-      padding: 8px 21px; }
+      padding: 8px 21px;
+      max-width: calc( 100% + 8px); }
   .wp-block-jetpack-layout-grid.wp-block-jetpack-layout-grid__padding-medium .wp-block-jetpack-layout-grid-column {
     padding: 16px; }
     .wp-block-jetpack-layout-grid.wp-block-jetpack-layout-grid__padding-medium .wp-block-jetpack-layout-grid-column.has-background {
-      padding: 16px 29px; }
+      padding: 16px 29px;
+      max-width: calc( 100% + 16px); }
   .wp-block-jetpack-layout-grid.wp-block-jetpack-layout-grid__padding-large .wp-block-jetpack-layout-grid-column {
     padding: 24px; }
     .wp-block-jetpack-layout-grid.wp-block-jetpack-layout-grid__padding-large .wp-block-jetpack-layout-grid-column.has-background {
-      padding: 24px 37px; }
+      padding: 24px 37px;
+      max-width: calc( 100% + 24px); }
   .wp-block-jetpack-layout-grid.wp-block-jetpack-layout-grid__padding-huge .wp-block-jetpack-layout-grid-column {
     padding: 48px; }
     .wp-block-jetpack-layout-grid.wp-block-jetpack-layout-grid__padding-huge .wp-block-jetpack-layout-grid-column.has-background {
-      padding: 48px 61px; }
+      padding: 48px 61px;
+      max-width: calc( 100% + 48px); }
 
 /**
  * Individual Column Options


### PR DESCRIPTION
Partially fixes #131. (#141 fixes the rest)

#113 added a max-width to columns. This broke columns with background colors, because they work by using negative margins to make the columns wider than they appear. (i.e. a column with 24px of negative margins needs to be 100% + 48px wide in order to not show gaps)

This PR fixes that issue, by customizing that max-width per padding. It's not super clean, but it should address the situation where child contents are wider than the column.

To test:

- Try content with columns that have background colors set (use preset colors until #141 is fixed) and try with various column paddings.
- Bonus: test the above in Firefox, but with a Jepack Slideshow block inside one of the columns.