### PR TITLE
Polish duotone filter

### DIFF
--- a/blocks/duotone-filter/duotone.php
+++ b/blocks/duotone-filter/duotone.php
@@ -23,12 +23,19 @@ if ( ! function_exists( 'hex2rgb' ) ) {
 }
 
 // phpcs:disable
+$duotone_selector = 'img.wp-image-' . $block['attrs']['id'];
 $duotone_id = $block['attrs']['duotoneId'];
 $duotone_dark = hex2rgb( $block['attrs']['duotoneDark'] );
 $duotone_light = hex2rgb( $block['attrs']['duotoneLight'] );
 // phpcs:enable
 
 ?>
+
+<style>
+	<?php echo $duotone_selector; ?> {
+		filter: url( <?php echo '#' . $duotone_id; ?> );
+	}
+</style>
 
 <svg
 	xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -37,7 +44,7 @@ $duotone_light = hex2rgb( $block['attrs']['duotoneLight'] );
 	height="0"
 	focusable="false"
 	role="none"
-	style="visibility: hidden !important; position: absolute !important; left: -9999px !important; overflow: hidden !important;"
+	style="visibility: hidden; position: absolute; left: -9999px; overflow: hidden;"
 >
 	<defs>
 		<filter id="<?php echo $duotone_id; ?>">

--- a/blocks/duotone-filter/duotone.php
+++ b/blocks/duotone-filter/duotone.php
@@ -24,7 +24,7 @@ if ( ! function_exists( 'hex2rgb' ) ) {
 
 // phpcs:disable
 $duotone_id = $block['attrs']['duotoneId'];
-$duotone_selector = '.wp-block-image.' . $duotone_id . ' > img';
+$duotone_selector = '.wp-block-image.' . $duotone_id . ' img';
 $duotone_dark = hex2rgb( $block['attrs']['duotoneDark'] );
 $duotone_light = hex2rgb( $block['attrs']['duotoneLight'] );
 // phpcs:enable

--- a/blocks/duotone-filter/duotone.php
+++ b/blocks/duotone-filter/duotone.php
@@ -1,26 +1,6 @@
 <?php
 
-if ( ! function_exists( 'hex2rgb' ) ) {
-	function hex2rgb( $color ) {
-		if ( strlen( $color ) === 4 ) {
-			$r = hexdec( substr( $color, 1, 1 ) . substr( $color, 1, 1 ) );
-			$g = hexdec( substr( $color, 2, 1 ) . substr( $color, 2, 1 ) );
-			$b = hexdec( substr( $color, 3, 1 ) . substr( $color, 3, 1 ) );
-		} elseif ( strlen( $color ) === 7 ) {
-			$r = hexdec( substr( $color, 1, 2 ) );
-			$g = hexdec( substr( $color, 3, 2 ) );
-			$b = hexdec( substr( $color, 5, 2 ) );
-		} else {
-			return array();
-		}
-
-		return array(
-			'r' => $r / 0xff,
-			'g' => $g / 0xff,
-			'b' => $b / 0xff,
-		);
-	}
-}
+include_once 'utils.php';
 
 // phpcs:disable
 $duotone_id = $block['attrs']['duotoneId'];

--- a/blocks/duotone-filter/duotone.php
+++ b/blocks/duotone-filter/duotone.php
@@ -25,7 +25,6 @@ if ( ! function_exists( 'hex2rgb' ) ) {
 // phpcs:disable
 $duotone_id = $block['attrs']['duotoneId'];
 $duotone_selector = '.wp-block-image.' . $duotone_id . ' > img';
-$duotone_url = '#' . $duotone_id;
 $duotone_dark = hex2rgb( $block['attrs']['duotoneDark'] );
 $duotone_light = hex2rgb( $block['attrs']['duotoneLight'] );
 // phpcs:enable
@@ -34,7 +33,7 @@ $duotone_light = hex2rgb( $block['attrs']['duotoneLight'] );
 
 <style>
 	<?php echo $duotone_selector; ?> {
-		filter: url( <?php echo $duotone_url; ?> );
+		filter: url( <?php echo '#' . $duotone_id; ?> );
 	}
 </style>
 

--- a/blocks/duotone-filter/duotone.php
+++ b/blocks/duotone-filter/duotone.php
@@ -51,9 +51,9 @@ $duotone_light = hex2rgb( $block['attrs']['duotoneLight'] );
 			<feColorMatrix
 				type="matrix"
 				<?php // phpcs:disable ?>
-				values=".2989 .5870 .1140 0 0
-				        .2989 .5870 .1140 0 0
-				        .2989 .5870 .1140 0 0
+				values=".299 .587 .114 0 0
+				        .299 .587 .114 0 0
+				        .299 .587 .114 0 0
 				        0 0 0 1 0"
 				<?php // phpcs:enable ?>
 			/>

--- a/blocks/duotone-filter/duotone.php
+++ b/blocks/duotone-filter/duotone.php
@@ -23,8 +23,9 @@ if ( ! function_exists( 'hex2rgb' ) ) {
 }
 
 // phpcs:disable
-$duotone_selector = 'img.wp-image-' . $block['attrs']['id'];
 $duotone_id = $block['attrs']['duotoneId'];
+$duotone_selector = '.wp-block-image.' . $duotone_id . ' > img';
+$duotone_url = '#' . $duotone_id;
 $duotone_dark = hex2rgb( $block['attrs']['duotoneDark'] );
 $duotone_light = hex2rgb( $block['attrs']['duotoneLight'] );
 // phpcs:enable
@@ -33,7 +34,7 @@ $duotone_light = hex2rgb( $block['attrs']['duotoneLight'] );
 
 <style>
 	<?php echo $duotone_selector; ?> {
-		filter: url( <?php echo '#' . $duotone_id; ?> );
+		filter: url( <?php echo $duotone_url; ?> );
 	}
 </style>
 

--- a/blocks/duotone-filter/index.php
+++ b/blocks/duotone-filter/index.php
@@ -15,7 +15,6 @@ add_action( 'init', function() {
 	add_filter( 'render_block', function ( $block_content, $block ) {
 		if (
 			! is_supported_block( $block ) ||
-			! isset( $block['attrs']['id'] ) ||
 			! isset( $block['attrs']['duotoneId'] ) ||
 			! isset( $block['attrs']['duotoneDark'] ) ||
 			! isset( $block['attrs']['duotoneLight'] )

--- a/blocks/duotone-filter/index.php
+++ b/blocks/duotone-filter/index.php
@@ -8,7 +8,7 @@ add_action( 'init', function() {
 	] );
 
 	function is_supported_block( $block ) {
-		$supported_blocks = [ 'core/image', 'core/cover' ];
+		$supported_blocks = [ 'core/image' ];
 		return in_array( $block['blockName'], $supported_blocks, true );
 	}
 

--- a/blocks/duotone-filter/index.php
+++ b/blocks/duotone-filter/index.php
@@ -26,6 +26,6 @@ add_action( 'init', function() {
 		include 'duotone.php';
 		$duotone = ob_get_clean();
 
-		return $duotone . $block_content;
+		return $block_content . $duotone;
 	}, 10, 2 );
 } );

--- a/blocks/duotone-filter/index.php
+++ b/blocks/duotone-filter/index.php
@@ -15,9 +15,10 @@ add_action( 'init', function() {
 	add_filter( 'render_block', function ( $block_content, $block ) {
 		if (
 			! is_supported_block( $block ) ||
-			! array_key_exists( 'duotoneId', $block['attrs'] ) ||
-			! array_key_exists( 'duotoneDark', $block['attrs'] ) ||
-			! array_key_exists( 'duotoneLight', $block['attrs'] )
+			! isset( $block['attrs']['id'] ) ||
+			! isset( $block['attrs']['duotoneId'] ) ||
+			! isset( $block['attrs']['duotoneDark'] ) ||
+			! isset( $block['attrs']['duotoneLight'] )
 		) {
 			return $block_content;
 		}

--- a/blocks/duotone-filter/src/duotone.js
+++ b/blocks/duotone-filter/src/duotone.js
@@ -59,9 +59,9 @@ ${ selector } {
 							type="matrix"
 							// prettier-ignore
 							values=".2989 .5870 .1140 0 0
-						        .2989 .5870 .1140 0 0
-						        .2989 .5870 .1140 0 0
-						        0 0 0 1 0"
+							        .2989 .5870 .1140 0 0
+							        .2989 .5870 .1140 0 0
+							        0 0 0 1 0"
 						/>
 						<feComponentTransfer colorInterpolationFilters="sRGB">
 							<feFuncR

--- a/blocks/duotone-filter/src/duotone.js
+++ b/blocks/duotone-filter/src/duotone.js
@@ -27,52 +27,61 @@ const hex2rgb = ( color = '' ) => {
 	};
 };
 
-function Duotone( { id: duotoneId, darkColor, lightColor } ) {
+function Duotone( { id: duotoneId, darkColor, lightColor, selector } ) {
 	const duotoneDark = hex2rgb( darkColor );
 	const duotoneLight = hex2rgb( lightColor );
 
+	const stylesheet = `
+${ selector } {
+	filter: url( #${ duotoneId } );
+}
+`;
+
 	return (
-		<SVG
-			xmlnsXlink="http://www.w3.org/1999/xlink"
-			viewBox="0 0 0 0"
-			width="0"
-			height="0"
-			focusable="false"
-			role="none"
-			style={ {
-				visibility: 'hidden',
-				position: 'absolute',
-				left: '-9999px',
-				overflow: 'hidden',
-			} }
-		>
-			<defs>
-				<filter id={ duotoneId }>
-					<feColorMatrix
-						type="matrix"
-						// prettier-ignore
-						values=".2989 .5870 .1140 0 0
+		<>
+			<SVG
+				xmlnsXlink="http://www.w3.org/1999/xlink"
+				viewBox="0 0 0 0"
+				width="0"
+				height="0"
+				focusable="false"
+				role="none"
+				style={ {
+					visibility: 'hidden',
+					position: 'absolute',
+					left: '-9999px',
+					overflow: 'hidden',
+				} }
+			>
+				<defs>
+					<filter id={ duotoneId }>
+						<feColorMatrix
+							type="matrix"
+							// prettier-ignore
+							values=".2989 .5870 .1140 0 0
 						        .2989 .5870 .1140 0 0
 						        .2989 .5870 .1140 0 0
 						        0 0 0 1 0"
-					/>
-					<feComponentTransfer colorInterpolationFilters="sRGB">
-						<feFuncR
-							type="table"
-							tableValues={ `${ duotoneDark.r } ${ duotoneLight.r }` }
 						/>
-						<feFuncG
-							type="table"
-							tableValues={ `${ duotoneDark.g } ${ duotoneLight.g }` }
-						/>
-						<feFuncB
-							type="table"
-							tableValues={ `${ duotoneDark.b } ${ duotoneLight.b }` }
-						/>
-					</feComponentTransfer>
-				</filter>
-			</defs>
-		</SVG>
+						<feComponentTransfer colorInterpolationFilters="sRGB">
+							<feFuncR
+								type="table"
+								tableValues={ `${ duotoneDark.r } ${ duotoneLight.r }` }
+							/>
+							<feFuncG
+								type="table"
+								tableValues={ `${ duotoneDark.g } ${ duotoneLight.g }` }
+							/>
+							<feFuncB
+								type="table"
+								tableValues={ `${ duotoneDark.b } ${ duotoneLight.b }` }
+							/>
+						</feComponentTransfer>
+					</filter>
+				</defs>
+			</SVG>
+			<style dangerouslySetInnerHTML={ { __html: stylesheet } } />
+		</>
 	);
 }
 

--- a/blocks/duotone-filter/src/duotone.js
+++ b/blocks/duotone-filter/src/duotone.js
@@ -3,29 +3,10 @@
  */
 import { SVG } from '@wordpress/components';
 
-const hex2rgb = ( color = '' ) => {
-	let r = '0';
-	let g = '0';
-	let b = '0';
-
-	if ( color.length === 4 ) {
-		r = '0x' + color[ 1 ] + color[ 1 ];
-		g = '0x' + color[ 2 ] + color[ 2 ];
-		b = '0x' + color[ 3 ] + color[ 3 ];
-	} else if ( color.length === 7 ) {
-		r = '0x' + color[ 1 ] + color[ 2 ];
-		g = '0x' + color[ 3 ] + color[ 4 ];
-		b = '0x' + color[ 5 ] + color[ 6 ];
-	} else {
-		return {};
-	}
-
-	return {
-		r: r / 0xff,
-		g: g / 0xff,
-		b: b / 0xff,
-	};
-};
+/**
+ * Internal dependencies
+ */
+import { hex2rgb } from './utils';
 
 function Duotone( { id: duotoneId, darkColor, lightColor, selector } ) {
 	const duotoneDark = hex2rgb( darkColor );

--- a/blocks/duotone-filter/src/duotone.js
+++ b/blocks/duotone-filter/src/duotone.js
@@ -58,9 +58,9 @@ ${ selector } {
 						<feColorMatrix
 							type="matrix"
 							// prettier-ignore
-							values=".2989 .5870 .1140 0 0
-							        .2989 .5870 .1140 0 0
-							        .2989 .5870 .1140 0 0
+							values=".299 .587 .114 0 0
+							        .299 .587 .114 0 0
+							        .299 .587 .114 0 0
 							        0 0 0 1 0"
 						/>
 						<feComponentTransfer colorInterpolationFilters="sRGB">

--- a/blocks/duotone-filter/src/index.js
+++ b/blocks/duotone-filter/src/index.js
@@ -18,6 +18,9 @@ import { __ } from '@wordpress/i18n';
  */
 import Duotone from './duotone';
 
+const FALLBACK_DARK_COLOR = '#000';
+const FALLBACK_LIGHT_COLOR = '#fff';
+
 const SUPPORTED_BLOCKS = [ 'core/image' ];
 
 export const isSupportedBlock = ( blockName ) =>
@@ -81,8 +84,8 @@ const withDuotoneEditorControls = createHigherOrderComponent(
 		}, [ instanceId ] );
 
 		const [
-			defaultDarkColor = '#000',
-			defaultLightColor = '#FFF',
+			defaultDarkColor = FALLBACK_DARK_COLOR,
+			defaultLightColor = FALLBACK_LIGHT_COLOR,
 		] = useSelect( ( select ) => {
 			const { colors } = select( 'core/block-editor' ).getSettings();
 			return colors
@@ -119,7 +122,11 @@ const withDuotoneEditorControls = createHigherOrderComponent(
 										! attributes.duotoneLight
 									) {
 										setAttributes( {
-											duotoneLight: defaultLightColor,
+											duotoneLight:
+												duotoneDark !==
+												defaultLightColor
+													? defaultLightColor
+													: FALLBACK_LIGHT_COLOR,
 										} );
 									}
 									setAttributes( { duotoneDark } );
@@ -134,7 +141,11 @@ const withDuotoneEditorControls = createHigherOrderComponent(
 										! attributes.duotoneDark
 									) {
 										setAttributes( {
-											duotoneDark: defaultDarkColor,
+											duotoneDark:
+												duotoneLight ===
+												defaultDarkColor
+													? defaultDarkColor
+													: FALLBACK_DARK_COLOR,
 										} );
 									}
 									setAttributes( { duotoneLight } );

--- a/blocks/duotone-filter/src/index.js
+++ b/blocks/duotone-filter/src/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { InspectorControls, PanelColorSettings } from '@wordpress/block-editor';
@@ -89,6 +94,19 @@ const withDuotoneEditorControls = createHigherOrderComponent(
 	'withDuotoneEditorControls'
 );
 
+function addDuotoneFilterStyle( props, block, attributes ) {
+	if (
+		! isSupportedBlock( block.name ) ||
+		! attributes.duotoneDark ||
+		! attributes.duotoneLight ||
+		! attributes.duotoneId
+	) {
+		return props;
+	}
+
+	return { className: classnames( props.className, attributes.duotoneId ) };
+}
+
 export function registerBlock() {
 	addFilter(
 		'editor.BlockEdit',
@@ -99,5 +117,10 @@ export function registerBlock() {
 		'blocks.registerBlockType',
 		'a8c/duotone-filter/add-attributes',
 		withDuotoneAttributes
+	);
+	addFilter(
+		'blocks.getSaveContent.extraProps',
+		'a8c/duotone-filter/add-filter-style',
+		addDuotoneFilterStyle
 	);
 }

--- a/blocks/duotone-filter/src/index.js
+++ b/blocks/duotone-filter/src/index.js
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import Duotone from './duotone';
+import { hex2rgb } from './utils';
 
 const FALLBACK_DARK_COLOR = '#000';
 const FALLBACK_LIGHT_COLOR = '#fff';
@@ -50,20 +51,7 @@ const withDuotoneAttributes = ( settings, blockName ) => {
  * @return {number} Luminance of the color
  */
 const toLuminance = ( color ) => {
-	let r = '0';
-	let g = '0';
-	let b = '0';
-
-	if ( color.length === 7 ) {
-		r = '0x' + color[ 1 ] + color[ 2 ];
-		g = '0x' + color[ 3 ] + color[ 4 ];
-		b = '0x' + color[ 5 ] + color[ 6 ];
-	} else if ( color.length === 4 ) {
-		r = '0x' + color[ 1 ] + color[ 1 ];
-		g = '0x' + color[ 2 ] + color[ 2 ];
-		b = '0x' + color[ 3 ] + color[ 3 ];
-	}
-
+	const { r, g, b } = hex2rgb( color );
 	return r * 0.299 + g * 0.587 + b * 0.114;
 };
 

--- a/blocks/duotone-filter/src/index.js
+++ b/blocks/duotone-filter/src/index.js
@@ -36,7 +36,7 @@ const withDuotoneAttributes = ( settings, blockName ) => {
 
 const withDuotoneEditorControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
-		const { name: blockName, attributes, setAttributes } = props;
+		const { name: blockName, attributes, setAttributes, clientId } = props;
 
 		if ( ! isSupportedBlock( blockName ) ) {
 			return <BlockEdit { ...props } />;
@@ -75,43 +75,19 @@ const withDuotoneEditorControls = createHigherOrderComponent(
 				{ attributes.duotoneDark &&
 				attributes.duotoneLight &&
 				attributes.duotoneId ? (
-					<>
-						<Duotone
-							id={ attributes.duotoneId }
-							darkColor={ attributes.duotoneDark }
-							lightColor={ attributes.duotoneLight }
-						/>
-						<div
-							style={ {
-								filter: `url( #${ attributes.duotoneId } )`,
-							} }
-						>
-							<BlockEdit { ...props } />
-						</div>
-					</>
-				) : (
-					<BlockEdit { ...props } />
-				) }
+					<Duotone
+						selector={ `#block-${ clientId } img` }
+						id={ attributes.duotoneId }
+						darkColor={ attributes.duotoneDark }
+						lightColor={ attributes.duotoneLight }
+					/>
+				) : null }
+				<BlockEdit { ...props } />
 			</>
 		);
 	},
 	'withDuotoneEditorControls'
 );
-
-function addDuotoneFilterStyle( props, block, attributes ) {
-	if (
-		! isSupportedBlock( block.name ) ||
-		! attributes.duotoneDark ||
-		! attributes.duotoneLight ||
-		! attributes.duotoneId
-	) {
-		return props;
-	}
-
-	const { style = {} } = props;
-
-	return { style: { ...style, filter: `url( #${ attributes.duotoneId } )` } };
-}
 
 export function registerBlock() {
 	addFilter(
@@ -123,10 +99,5 @@ export function registerBlock() {
 		'blocks.registerBlockType',
 		'a8c/duotone-filter/add-attributes',
 		withDuotoneAttributes
-	);
-	addFilter(
-		'blocks.getSaveContent.extraProps',
-		'a8c/duotone-filter/add-filter-style',
-		addDuotoneFilterStyle
 	);
 }

--- a/blocks/duotone-filter/src/index.js
+++ b/blocks/duotone-filter/src/index.js
@@ -130,7 +130,7 @@ const withDuotoneEditorControls = createHigherOrderComponent(
 									) {
 										setAttributes( {
 											duotoneDark:
-												duotoneLight ===
+												duotoneLight !==
 												defaultDarkColor
 													? defaultDarkColor
 													: FALLBACK_DARK_COLOR,

--- a/blocks/duotone-filter/src/index.js
+++ b/blocks/duotone-filter/src/index.js
@@ -77,6 +77,7 @@ const withDuotoneEditorControls = createHigherOrderComponent(
 						] }
 					/>
 				</InspectorControls>
+				<BlockEdit { ...props } />
 				{ attributes.duotoneDark &&
 				attributes.duotoneLight &&
 				attributes.duotoneId ? (
@@ -87,7 +88,6 @@ const withDuotoneEditorControls = createHigherOrderComponent(
 						lightColor={ attributes.duotoneLight }
 					/>
 				) : null }
-				<BlockEdit { ...props } />
 			</>
 		);
 	},

--- a/blocks/duotone-filter/src/index.js
+++ b/blocks/duotone-filter/src/index.js
@@ -45,12 +45,12 @@ const withDuotoneAttributes = ( settings, blockName ) => {
 };
 
 /**
- * Convert a hex color to luminance.
+ * Convert a hex color to perceived brightness.
  *
  * @param {string} color Hex color
- * @return {number} Luminance of the color
+ * @return {number} Perceived brightness of the color
  */
-const toLuminance = ( color ) => {
+const toBrightness = ( color ) => {
 	const { r, g, b } = hex2rgb( color );
 	return r * 0.299 + g * 0.587 + b * 0.114;
 };
@@ -79,14 +79,14 @@ const withDuotoneEditorControls = createHigherOrderComponent(
 			return colors
 				.map( ( { color } ) => ( {
 					color,
-					luminance: toLuminance( color ),
+					brightness: toBrightness( color ),
 				} ) )
 				.reduce( ( [ min, max ], current ) => {
 					return [
-						! min || current.luminance < min.luminance
+						! min || current.brightness < min.brightness
 							? current
 							: min,
-						! max || current.luminance > max.luminance
+						! max || current.brightness > max.brightness
 							? current
 							: max,
 					];

--- a/blocks/duotone-filter/src/index.js
+++ b/blocks/duotone-filter/src/index.js
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
  */
 import Duotone from './duotone';
 
-const SUPPORTED_BLOCKS = [ 'core/image', 'core/cover' ];
+const SUPPORTED_BLOCKS = [ 'core/image' ];
 
 export const isSupportedBlock = ( blockName ) =>
 	SUPPORTED_BLOCKS.includes( blockName );

--- a/blocks/duotone-filter/src/index.js
+++ b/blocks/duotone-filter/src/index.js
@@ -64,7 +64,7 @@ const toLuminance = ( color ) => {
 		b = '0x' + color[ 3 ] + color[ 3 ];
 	}
 
-	return r * 0.299 + g * 0.587 + b * 0.114;
+	return r * 0.2989 + g * 0.587 + b * 0.114;
 };
 
 const withDuotoneEditorControls = createHigherOrderComponent(

--- a/blocks/duotone-filter/src/index.js
+++ b/blocks/duotone-filter/src/index.js
@@ -64,7 +64,7 @@ const toLuminance = ( color ) => {
 		b = '0x' + color[ 3 ] + color[ 3 ];
 	}
 
-	return r * 0.2989 + g * 0.587 + b * 0.114;
+	return r * 0.299 + g * 0.587 + b * 0.114;
 };
 
 const withDuotoneEditorControls = createHigherOrderComponent(

--- a/blocks/duotone-filter/src/index.js
+++ b/blocks/duotone-filter/src/index.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import { InspectorControls, PanelColorSettings } from '@wordpress/block-editor';
 import { createHigherOrderComponent, useInstanceId } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 
@@ -80,8 +80,6 @@ const withDuotoneEditorControls = createHigherOrderComponent(
 			} );
 		}, [ instanceId ] );
 
-		const [ autoSet, setAutoSet ] = useState( null );
-
 		const [
 			defaultDarkColor = '#000',
 			defaultLightColor = '#FFF',
@@ -120,20 +118,9 @@ const withDuotoneEditorControls = createHigherOrderComponent(
 										duotoneDark &&
 										! attributes.duotoneLight
 									) {
-										setAutoSet( 'light' );
 										setAttributes( {
 											duotoneLight: defaultLightColor,
 										} );
-									} else if (
-										! duotoneDark &&
-										autoSet === 'light'
-									) {
-										setAutoSet( null );
-										setAttributes( {
-											duotoneLight: null,
-										} );
-									} else if ( autoSet === 'dark' ) {
-										setAutoSet( null );
 									}
 									setAttributes( { duotoneDark } );
 								},
@@ -146,20 +133,9 @@ const withDuotoneEditorControls = createHigherOrderComponent(
 										duotoneLight &&
 										! attributes.duotoneDark
 									) {
-										setAutoSet( 'dark' );
 										setAttributes( {
 											duotoneDark: defaultDarkColor,
 										} );
-									} else if (
-										! duotoneLight &&
-										autoSet === 'dark'
-									) {
-										setAutoSet( null );
-										setAttributes( {
-											duotoneDark: null,
-										} );
-									} else if ( autoSet === 'light' ) {
-										setAutoSet( null );
 									}
 									setAttributes( { duotoneLight } );
 								},

--- a/blocks/duotone-filter/src/utils.js
+++ b/blocks/duotone-filter/src/utils.js
@@ -1,0 +1,23 @@
+export const hex2rgb = ( color = '' ) => {
+	let r = '0';
+	let g = '0';
+	let b = '0';
+
+	if ( color.length === 4 ) {
+		r = '0x' + color[ 1 ] + color[ 1 ];
+		g = '0x' + color[ 2 ] + color[ 2 ];
+		b = '0x' + color[ 3 ] + color[ 3 ];
+	} else if ( color.length === 7 ) {
+		r = '0x' + color[ 1 ] + color[ 2 ];
+		g = '0x' + color[ 3 ] + color[ 4 ];
+		b = '0x' + color[ 5 ] + color[ 6 ];
+	} else {
+		return {};
+	}
+
+	return {
+		r: r / 0xff,
+		g: g / 0xff,
+		b: b / 0xff,
+	};
+};

--- a/blocks/duotone-filter/utils.php
+++ b/blocks/duotone-filter/utils.php
@@ -1,0 +1,23 @@
+<?php
+
+if ( ! function_exists( 'hex2rgb' ) ) {
+	function hex2rgb( $color ) {
+		if ( strlen( $color ) === 4 ) {
+			$r = hexdec( substr( $color, 1, 1 ) . substr( $color, 1, 1 ) );
+			$g = hexdec( substr( $color, 2, 1 ) . substr( $color, 2, 1 ) );
+			$b = hexdec( substr( $color, 3, 1 ) . substr( $color, 3, 1 ) );
+		} elseif ( strlen( $color ) === 7 ) {
+			$r = hexdec( substr( $color, 1, 2 ) );
+			$g = hexdec( substr( $color, 3, 2 ) );
+			$b = hexdec( substr( $color, 5, 2 ) );
+		} else {
+			return array();
+		}
+
+		return array(
+			'r' => $r / 0xff,
+			'g' => $g / 0xff,
+			'b' => $b / 0xff,
+		);
+	}
+}


### PR DESCRIPTION
Followup from #88 with some improvements on the duotone filter to get this ready to ship :shipit: 

- [x] Render out stylesheet to apply the filter to only the media
- [x] Disable duotone for cover block (until structure is fixed in core WordPress/gutenberg#25171)
- [x] Is it necessary to sanitize block attributes, or is that already taken care of? EDIT: Looks like it's taken care of in `wp_pre_kses_block_attributes` called from `default-filters.php`
 

![duotone image with palette colors](https://user-images.githubusercontent.com/5129775/92551386-19da5800-f21b-11ea-9825-dcd95d975eb3.png)

![duotone image with custom colors](https://user-images.githubusercontent.com/5129775/92551395-1cd54880-f21b-11ea-9af8-39e947b20477.png)
