### PR TITLE
Fix: Add props passing into icons

### DIFF
--- a/blocks/layout-grid/src/icons.js
+++ b/blocks/layout-grid/src/icons.js
@@ -4,7 +4,7 @@
 
 import { Path, SVG } from '@wordpress/components';
 
-export const GridIcon = ( props = null ) => (
+export const GridIcon = ( props ) => (
 	<SVG xmlns="http://www.w3.org/2000/svg"
 		width="24" height="24"
 		viewBox="0 0 24 24"
@@ -14,7 +14,7 @@ export const GridIcon = ( props = null ) => (
 	</SVG>
 );
 
-export const GridColumnIcon = ( props = null ) => (
+export const GridColumnIcon = ( props ) => (
 	<SVG xmlns="http://www.w3.org/2000/svg"
 		width="24" height="24"
 		viewBox="0 0 24 24"

--- a/blocks/layout-grid/src/icons.js
+++ b/blocks/layout-grid/src/icons.js
@@ -4,74 +4,80 @@
 
 import { Path, SVG } from '@wordpress/components';
 
-export const GridIcon = () => (
+export const GridIcon = ( props = null ) => (
 	<SVG xmlns="http://www.w3.org/2000/svg"
 		width="24" height="24"
 		viewBox="0 0 24 24"
+		{ ...props }
 	>
 		<Path d="M19 6H6c-1.1 0-2 .9-2 2v9c0 1.1.9 2 2 2h13c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-7.5 11.5H6c-.3 0-.5-.2-.5-.5V8c0-.3.2-.5.5-.5h5.5v10zm4 0H13v-10h2.5v10zm4-.5c0 .3-.2.5-.5.5h-2v-10h2c.3 0 .5.2.5.5v9z" />
 	</SVG>
 );
 
-export const GridColumnIcon = () => (
+export const GridColumnIcon = ( props = null ) => (
 	<SVG xmlns="http://www.w3.org/2000/svg"
 		width="24" height="24"
 		viewBox="0 0 24 24"
+		{ ...props }
 	>
 		<Path d="M19 6H6c-1.1 0-2 .9-2 2v9c0 1.1.9 2 2 2h13c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zM5.5 17V8c0-.3.2-.5.5-.5h5.5v10H6c-.3 0-.5-.2-.5-.5zm14 0c0 .3-.2.5-.5.5h-2v-10h2c.3 0 .5.2.5.5v9z" />
 	</SVG>
 );
 
-const ColSetup1 = () => (
+const ColSetup1 = ( props ) => (
 	<SVG xmlns="http://www.w3.org/2000/svg"
 		width="48" height="48"
 		viewBox="0 0 48 48"
+		{ ...props }
 	>
 		<Path d="M7 12v24h34V12H7zm32 22H9V14h30v20z" />
 	</SVG>
 );
 
-const ColSetup2 = () => (
+const ColSetup2 = ( props ) => (
 	<SVG xmlns="http://www.w3.org/2000/svg"
 		width="48" height="48"
 		viewBox="0 0 48 48"
+		{ ...props }
 	>
 		<Path d="M7,12v24h34V12H7z M23,34H9V14h14V34z M39,34H25V14h14V34z" />
 	</SVG>
 );
 
-const ColSetup3 = () => (
+const ColSetup3 = ( props ) => (
 	<SVG xmlns="http://www.w3.org/2000/svg"
 		width="48" height="48"
 		viewBox="0 0 48 48"
+		{ ...props }
 	>
 		<Path d="M7 12v24h34V12H7zm23 2h9v20h-9V14zm-2 20h-8V14h8v20zM9 14h9v20H9V14z" />
 	</SVG>
 );
 
-const ColSetup4 = () => (
+const ColSetup4 = ( props ) => (
 	<SVG xmlns="http://www.w3.org/2000/svg"
 		width="48" height="48"
 		viewBox="0 0 48 48"
+		{ ...props }
 	>
 		<Path d="M7 12v24h34V12H7zm8 22H9V14h6v20zm8 0h-6V14h6v20zm8 0h-6V14h6v20zm8 0h-6V14h6v20z" />
 	</SVG>
 );
 
-const ColumnIcon = ( { columns } ) => {
+const ColumnIcon = ( { columns, ...props } ) => {
 	if ( columns === 4 ) {
-		return <ColSetup4 />;
+		return <ColSetup4 { ...props } />;
 	}
 
 	if ( columns === 3 ) {
-		return <ColSetup3 />;
+		return <ColSetup3 { ...props } />;
 	}
 
 	if ( columns === 2 ) {
-		return <ColSetup2 />;
+		return <ColSetup2 { ...props } />;
 	}
 
-	return <ColSetup1 />;
+	return <ColSetup1 { ...props } />;
 };
 
 export default ColumnIcon;


### PR DESCRIPTION
Currently the icons don't allow for props to be passed to the main SVG component. 

The problem is that this prevents the mobile Gutenberg editor from passing in the correct fill prop for the icon.

On the mobile inserted.
Before:
<img width="246" alt="Screen Shot 2020-09-08 at 12 34 53 PM" src="https://user-images.githubusercontent.com/115071/92653399-27d3bb80-f2a3-11ea-8aca-f641e6ac3837.png">

After:
![Screen Shot 2020-09-09 at 12 50 15 PM](https://user-images.githubusercontent.com/115071/92653418-2c986f80-f2a3-11ea-9e7c-4250b6dba767.png)


**To tests**

I build a new version of the layout-grid plugin. 
using `yarn plugin layout-grid` 
and then `yarn bundle` 

And then I installed the plugin on my site. 
And tried to find if the icons have changed anywhere with undesirable outcomes. 

See:
![Screen Shot 2020-09-09 at 1 44 38 PM](https://user-images.githubusercontent.com/115071/92655436-46878180-f2a6-11ea-97fa-d63dcca12411.png)

![Screen Shot 2020-09-09 at 1 44 11 PM](https://user-images.githubusercontent.com/115071/92655430-44bdbe00-f2a6-11ea-85da-4a1ad52638b0.png)

![Screen Shot 2020-09-09 at 1 44 17 PM](https://user-images.githubusercontent.com/115071/92655433-45565480-f2a6-11ea-9294-59247301eec0.png)

![Screen Shot 2020-09-09 at 1 44 30 PM](https://user-images.githubusercontent.com/115071/92655435-45eeeb00-f2a6-11ea-9981-12155093a780.png)

To test it on mobile I followed the instructions in https://github.com/wordpress-mobile/gutenberg-mobile/pull/2582 
and then patched the icon file. Which fixed how the icons appeared. 
