### PR TITLE
Fix color palette errors

### DIFF
--- a/blocks/starscape/src/edit.js
+++ b/blocks/starscape/src/edit.js
@@ -13,10 +13,10 @@ import {
 	RichText,
 	withColors,
 	__experimentalPanelColorGradientSettings as PanelColorGradientSettings,
+	__experimentalUseEditorFeature as useEditorFeature,
 } from '@wordpress/block-editor';
 import { BaseControl, PanelBody, RangeControl } from '@wordpress/components';
 import { compose, withInstanceId } from '@wordpress/compose';
-import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -34,9 +34,8 @@ const Edit = ( {
 	setAttributes,
 	className,
 } ) => {
-	const themeColors = useSelect(
-		( select ) => select( 'core/block-editor' ).getSettings().colors
-	);
+	const themeColors = useEditorFeature( 'color.palette' ) || [];
+
 	return (
 		<>
 			<BlockControls>

--- a/blocks/waves/src/edit.js
+++ b/blocks/waves/src/edit.js
@@ -11,6 +11,7 @@ import {
 	PanelColorSettings,
 	InnerBlocks,
 	__experimentalUnitControl as UnitControl,
+	__experimentalUseEditorFeature as useEditorFeature,
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -19,16 +20,11 @@ import {
 	BaseControl,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-const DEFAULT_COLORS = {
-	color1: '#000',
-	color2: '#555',
-	color3: '#AAA',
-	color4: '#FFF',
-};
+const DEFAULT_COLOR_PALETTE = [ { color: '#000' }, { color: '#FFF' } ];
 
 const MIN_HEIGHT = 50;
 
@@ -108,27 +104,19 @@ function Edit( { attributes, className, isSelected, setAttributes } ) {
 	const [ temporaryMinHeight, setTemporaryMinHeight ] = useState( null );
 	const [ isResizing, setIsResizing ] = useState( false );
 
-	const themeColors = useSelect(
-		( select ) => select( 'core/block-editor' ).getSettings().colors,
-		[]
-	);
+	const colorPalette = useEditorFeature( 'color.palette' );
+
+	const themeColors = colorPalette?.length
+		? colorPalette
+		: DEFAULT_COLOR_PALETTE;
+
 	const colors = {
-		color1:
-			attributes.color1 ||
-			themeColors[ 0 ].color ||
-			DEFAULT_COLORS.color1,
-		color2:
-			attributes.color2 ||
-			themeColors[ 0 ].color ||
-			DEFAULT_COLORS.color2,
+		color1: attributes.color1 || themeColors[ 0 ].color,
+		color2: attributes.color2 || themeColors[ 0 ].color,
 		color3:
-			attributes.color3 ||
-			themeColors[ 1 % themeColors.length ].color ||
-			DEFAULT_COLORS.color3,
+			attributes.color3 || themeColors[ 1 % themeColors.length ].color,
 		color4:
-			attributes.color4 ||
-			themeColors[ 2 % themeColors.length ].color ||
-			DEFAULT_COLORS.color4,
+			attributes.color4 || themeColors[ 2 % themeColors.length ].color,
 	};
 
 	const updatePreview = ( newAttributes = {} ) =>


### PR DESCRIPTION
WordPress/gutenberg#25419 introduced a breaking change that's being discussed in WordPress/gutenberg#25652.

The Starscape, Waves, and Duotone blocks rely on default values being set; however, the default values no longer exist, causing errors when trying to access them.

There is also a new `useEditorFeature` API that didn't exist when Starscape was created and was still very new when Waves was created which provides a better way of accessing the theme color palette. This new API should be used for accessing colors in the future.