### PR TITLE
Fix grid column not having ‘has-background’ with custom colour

### DIFF
--- a/blocks/layout-grid/src/grid-column/save.js
+++ b/blocks/layout-grid/src/grid-column/save.js
@@ -21,7 +21,7 @@ const save = ( { attributes = {} } ) => {
 	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 	const classes = classnames( className, {
 		[ 'wp-block-jetpack-layout-grid__padding-' + padding ]: true,
-		'has-background': backgroundColor,
+		'has-background': backgroundColor || customBackgroundColor,
 		[ backgroundClass ]: backgroundClass,
 		[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
 	} );


### PR DESCRIPTION
Add `has-background` when a custom colour is used.

Fixes #141 