### PR TITLE
Fix layout grid in site editor.

### DIFF
--- a/blocks/layout-grid/src/grid.scss
+++ b/blocks/layout-grid/src/grid.scss
@@ -49,7 +49,7 @@
 }
 
 // Editor grid styles
-.block-editor-page .wp-block-jetpack-layout-grid {
+.wp-block-jetpack-layout-grid {
 	// These three rules are only necessary for Safari.
 	// Safari interprets percentages in CSS grid differently.
 	// Flex causes children to "stretch", fixing that interpretation.

--- a/blocks/layout-grid/src/grid.scss
+++ b/blocks/layout-grid/src/grid.scss
@@ -49,7 +49,7 @@
 }
 
 // Editor grid styles
-.block-editor .wp-block-jetpack-layout-grid {
+.block-editor-page .wp-block-jetpack-layout-grid {
 	// These three rules are only necessary for Safari.
 	// Safari interprets percentages in CSS grid differently.
 	// Flex causes children to "stretch", fixing that interpretation.


### PR DESCRIPTION
This PR fixs #154 where the layout grid did not work in the site editor. The rules were simply not output, because https://github.com/Automattic/block-experiments/commit/4ac3fb6166024cc447725b8c5a5883b4cadd2c89 targets a rule that exists only in the post editor.

This PR hopes to keep the intent of that commit in place — scoping the rules only to the block editor — but target a class that exists in both the site and post editor.

Before:

<img width="1249" alt="Screenshot 2020-11-16 at 09 39 52" src="https://user-images.githubusercontent.com/1204802/99231346-c83ce380-27f0-11eb-9776-63889ac9b70e.png">


After:

<img width="1181" alt="Screenshot 2020-11-16 at 09 46 02" src="https://user-images.githubusercontent.com/1204802/99231352-ca06a700-27f0-11eb-8d67-e78bb6b64168.png">
