### PR TITLE
Add a hyphen, in those browsers that support it, to long words that are broken across lines

### DIFF
--- a/blocks/layout-grid/front.css
+++ b/blocks/layout-grid/front.css
@@ -1030,7 +1030,10 @@
             grid-row-start: 4; } }
   .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column * {
     word-break: break-word;
-    word-wrap: break-word; }
+    word-wrap: break-word;
+    -webkit-hyphens: auto;
+        -ms-hyphens: auto;
+            hyphens: auto; }
   .wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__none {
     grid-gap: 0px; }
   .wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__small {

--- a/blocks/layout-grid/front.scss
+++ b/blocks/layout-grid/front.scss
@@ -106,6 +106,7 @@
 	.wp-block-jetpack-layout-grid-column * {
 		word-break: break-word;
 		word-wrap: break-word;
+		hyphens: auto;
 	}
 
 	&.wp-block-jetpack-layout-gutter__none {

--- a/blocks/layout-grid/src/grid.scss
+++ b/blocks/layout-grid/src/grid.scss
@@ -30,6 +30,7 @@
 	// Prevent long unbroken words from overflowing.
 	word-break: break-word; // For back-compat.
 	overflow-wrap: break-word; // New standard.
+	hyphens: auto;
 }
 
 .wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__none > .block-editor-inner-blocks > .block-editor-block-list__layout {


### PR DESCRIPTION
Currently long words break between lines to avoid breaking layout. This PR adds a hyphen were possible to make it more obvious that this has happened.

#### Testing

- Check out this PR to local env
- Add a two column layout grid block with a long/large word and check that a hyphen is added if the word breaks across lines.

Before:
<img width="664" alt="Screen Shot 2020-12-10 at 4 23 14 PM" src="https://user-images.githubusercontent.com/3629020/101717565-6710e300-3b04-11eb-82a2-0a9554aa7133.png">

After:
<img width="666" alt="Screen Shot 2020-12-10 at 4 21 26 PM" src="https://user-images.githubusercontent.com/3629020/101717589-72fca500-3b04-11eb-9659-0c3092bfdd05.png">

