### PR TITLE
Layout Grid: Enable mobile rendering in mobile editor.

### DIFF
--- a/blocks/layout-grid/front.scss
+++ b/blocks/layout-grid/front.scss
@@ -135,5 +135,5 @@
 
 // Ensure inner blocks with deliberate overflows are still constrained to column.
 .wp-block-jetpack-layout-grid-column {
-	max-width: 100%; 
+	max-width: 100%;
 }

--- a/blocks/layout-grid/src/constants.js
+++ b/blocks/layout-grid/src/constants.js
@@ -14,15 +14,17 @@ function getSpacingValues() {
 	];
 }
 
-export const getPaddingValues = () => (	[
-	{ value: 'none', label: __( 'No padding', 'layout-grid' ) },
-].concat( getSpacingValues() ) );
+export const getPaddingValues = () =>
+	[ { value: 'none', label: __( 'No padding', 'layout-grid' ) } ].concat(
+		getSpacingValues()
+	);
 
-export const getGutterValues = () => ( [
-	{ value: 'none', label: __( 'No gutter', 'layout-grid' ) },
-].concat( getSpacingValues() ) );
+export const getGutterValues = () =>
+	[ { value: 'none', label: __( 'No gutter', 'layout-grid' ) } ].concat(
+		getSpacingValues()
+	);
 
-export const getColumns = () => ( [
+export const getColumns = () => [
 	{
 		label: __( '1 column', 'layout-grid' ),
 		value: 1,
@@ -39,17 +41,29 @@ export const getColumns = () => ( [
 		label: __( '4 columns', 'layout-grid' ),
 		value: 4,
 	},
-] );
+];
 
 export const DEVICE_DESKTOP = 'Desktop';
 export const DEVICE_TABLET = 'Tablet';
 export const DEVICE_MOBILE = 'Mobile';
 
-export const getLayouts = () => ( [
-	{ value: DEVICE_DESKTOP, label: __( 'Desktop', 'layout-grid' ), icon: desktop },
-	{ value: DEVICE_TABLET, label: __( 'Tablet', 'layout-grid' ), icon: tablet  },
-	{ value: DEVICE_MOBILE, label: __( 'Mobile', 'layout-grid' ), icon: mobile },
-] );
+export const getLayouts = () => [
+	{
+		value: DEVICE_DESKTOP,
+		label: __( 'Desktop', 'layout-grid' ),
+		icon: desktop,
+	},
+	{
+		value: DEVICE_TABLET,
+		label: __( 'Tablet', 'layout-grid' ),
+		icon: tablet,
+	},
+	{
+		value: DEVICE_MOBILE,
+		label: __( 'Mobile', 'layout-grid' ),
+		icon: mobile,
+	},
+];
 
 export const MAX_COLUMNS = 4;
 

--- a/blocks/layout-grid/src/grid/edit.js
+++ b/blocks/layout-grid/src/grid/edit.js
@@ -62,7 +62,7 @@ const MINIMUM_RESIZE_SIZE = 50; // Empirically determined to be a good size
  * get the width of the editor, taking into account preview mode.
  */
 function getEditorDeviceWidth() {
-	const visualEditorEl = document.querySelector('.edit-post-visual-editor');
+	const visualEditorEl = document.querySelector('.editor-styles-wrapper');
 	const width = visualEditorEl ? visualEditorEl.offsetWidth : window.innerWidth;
 	if ( width < 600 ) {
 		return 'Mobile';

--- a/blocks/layout-grid/src/grid/edit.js
+++ b/blocks/layout-grid/src/grid/edit.js
@@ -56,6 +56,7 @@ import { getGridWidth, getDefaultSpan } from './grid-defaults';
 import ResizeGrid from './resize-grid';
 import LayoutGrid from './layout-grid';
 import PreviewDevice from './preview-device';
+import { desktop, grid, mobile } from '@wordpress/icons/build-types';
 
 const ALLOWED_BLOCKS = [ 'jetpack/layout-grid-column' ];
 const MINIMUM_RESIZE_SIZE = 50; // Empirically determined to be a good size
@@ -205,8 +206,8 @@ class Edit extends Component {
 	updateInspectorDevice( device ) {
 		this.setState( { inspectorDeviceType: device } );
 
-		// Only update if on desktop
-		if ( this.state.viewPort === 'Desktop' ) {
+		// Only update if not on mobile
+		if ( this.state.viewPort !== 'Mobile' ) {
 			this.props.setPreviewDeviceType( device );
 		}
 	}

--- a/blocks/layout-grid/src/grid/edit.js
+++ b/blocks/layout-grid/src/grid/edit.js
@@ -9,12 +9,13 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 
-import { InnerBlocks, InspectorControls } from '@wordpress/block-editor';
-import { Component, createRef } from '@wordpress/element';
 import {
+	InnerBlocks,
+	InspectorControls,
 	BlockControls,
 	BlockVerticalAlignmentToolbar,
 } from '@wordpress/block-editor';
+import { Component, createRef } from '@wordpress/element';
 import {
 	PanelBody,
 	TextControl,

--- a/blocks/layout-grid/src/grid/edit.js
+++ b/blocks/layout-grid/src/grid/edit.js
@@ -9,10 +9,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 
-import {
-	InnerBlocks,
-	InspectorControls,
-} from '@wordpress/block-editor';
+import { InnerBlocks, InspectorControls } from '@wordpress/block-editor';
 import { Component, createRef } from '@wordpress/element';
 import {
 	BlockControls,
@@ -50,7 +47,14 @@ import {
 	getGutterClasses,
 } from './css-classname';
 import ColumnIcon from '../icons';
-import { getLayouts, getColumns, DEVICE_BREAKPOINTS, getSpanForDevice, getOffsetForDevice, getGutterValues } from '../constants';
+import {
+	getLayouts,
+	getColumns,
+	DEVICE_BREAKPOINTS,
+	getSpanForDevice,
+	getOffsetForDevice,
+	getGutterValues,
+} from '../constants';
 import { getGridWidth, getDefaultSpan } from './grid-defaults';
 import ResizeGrid from './resize-grid';
 import LayoutGrid from './layout-grid';
@@ -62,8 +66,10 @@ const MINIMUM_RESIZE_SIZE = 50; // Empirically determined to be a good size
  * get the width of the editor, taking into account preview mode.
  */
 function getEditorDeviceWidth() {
-	const visualEditorEl = document.querySelector('.editor-styles-wrapper');
-	const width = visualEditorEl ? visualEditorEl.offsetWidth : window.innerWidth;
+	const visualEditorEl = document.querySelector( '.editor-styles-wrapper' );
+	const width = visualEditorEl
+		? visualEditorEl.offsetWidth
+		: window.innerWidth;
 	if ( width < 600 ) {
 		return 'Mobile';
 	} else if ( width < 1080 ) {
@@ -92,11 +98,23 @@ class Edit extends Component {
 		const columnValues = {};
 
 		for ( let pos = 0; pos < columns; pos++ ) {
-			for ( let device = 0; device < DEVICE_BREAKPOINTS.length; device++ ) {
-				const defaultSpan = getDefaultSpan( DEVICE_BREAKPOINTS[ device ], columns, pos );
+			for (
+				let device = 0;
+				device < DEVICE_BREAKPOINTS.length;
+				device++
+			) {
+				const defaultSpan = getDefaultSpan(
+					DEVICE_BREAKPOINTS[ device ],
+					columns,
+					pos
+				);
 
-				columnValues[ getSpanForDevice( pos, DEVICE_BREAKPOINTS[ device ] ) ] = defaultSpan;
-				columnValues[ getOffsetForDevice( pos, DEVICE_BREAKPOINTS[ device ] ) ] = 0;
+				columnValues[
+					getSpanForDevice( pos, DEVICE_BREAKPOINTS[ device ] )
+				] = defaultSpan;
+				columnValues[
+					getOffsetForDevice( pos, DEVICE_BREAKPOINTS[ device ] )
+				] = 0;
 			}
 		}
 
@@ -124,33 +142,41 @@ class Edit extends Component {
 
 	onResize = ( column, adjustment ) => {
 		const { attributes, columns } = this.props;
-		const grid = new LayoutGrid( attributes, this.state.renderDeviceType, columns );
+		const grid = new LayoutGrid(
+			attributes,
+			this.state.renderDeviceType,
+			columns
+		);
 		const adjustedGrid = grid.getAdjustedGrid( column, adjustment );
 
 		if ( adjustedGrid ) {
 			this.adjustGrid( adjustedGrid );
 		}
-	}
+	};
 
 	onChangeSpan = ( column, device, value ) => {
 		const { attributes, columns } = this.props;
 		const grid = new LayoutGrid( attributes, device, columns );
-		const adjustedGrid = grid.getAdjustedGrid( column, { span: parseInt( value, 10 ) } );
+		const adjustedGrid = grid.getAdjustedGrid( column, {
+			span: parseInt( value, 10 ),
+		} );
 
 		if ( adjustedGrid ) {
 			this.adjustGrid( adjustedGrid );
 		}
-	}
+	};
 
 	onChangeOffset = ( column, device, value ) => {
 		const { attributes, columns } = this.props;
 		const grid = new LayoutGrid( attributes, device, columns );
-		const adjustedGrid = grid.getAdjustedGrid( column, { start: grid.convertOffsetToStart( column, parseInt( value, 10 ) ) } );
+		const adjustedGrid = grid.getAdjustedGrid( column, {
+			start: grid.convertOffsetToStart( column, parseInt( value, 10 ) ),
+		} );
 
 		if ( adjustedGrid ) {
 			this.adjustGrid( adjustedGrid );
 		}
-	}
+	};
 
 	adjustGrid( grid ) {
 		const { setAttributes, attributes } = this.props;
@@ -166,12 +192,16 @@ class Edit extends Component {
 		const settings = [];
 
 		for ( let column = 0; column < columns; column++ ) {
-			const span = grid.getSpan( column ) || getDefaultSpan( device, columns, column );
+			const span =
+				grid.getSpan( column ) ||
+				getDefaultSpan( device, columns, column );
 			const offset = grid.getOffset( column ) || 0;
 
-			settings.push( (
+			settings.push(
 				<div className="jetpack-layout-grid-settings" key={ column }>
-					<strong>{ __( 'Column', 'layout-grid' ) } { column + 1 }</strong>
+					<strong>
+						{ __( 'Column', 'layout-grid' ) } { column + 1 }
+					</strong>
 					<div className="jetpack-layout-grid-settings__group">
 						<TextControl
 							type="number"
@@ -179,7 +209,9 @@ class Edit extends Component {
 							value={ offset || 0 }
 							min={ 0 }
 							max={ getGridWidth( device ) - 1 }
-							onChange={ ( value ) => this.onChangeOffset( column, device, value ) }
+							onChange={ ( value ) =>
+								this.onChangeOffset( column, device, value )
+							}
 						/>
 						<TextControl
 							type="number"
@@ -187,11 +219,13 @@ class Edit extends Component {
 							value={ span }
 							min={ 1 }
 							max={ getGridWidth( device ) }
-							onChange={ ( value ) => this.onChangeSpan( column, device, value ) }
+							onChange={ ( value ) =>
+								this.onChangeSpan( column, device, value )
+							}
 						/>
 					</div>
 				</div>
-			) );
+			);
 		}
 
 		return settings;
@@ -226,13 +260,18 @@ class Edit extends Component {
 			columnAttributes
 		);
 		const { gutterSize, addGutterEnds, verticalAlignment } = attributes;
-		const layoutGrid = new LayoutGrid( attributes, renderDeviceType, columns );
+		const layoutGrid = new LayoutGrid(
+			attributes,
+			renderDeviceType,
+			columns
+		);
 		const classes = classnames(
 			removeGridClasses( className ),
 			extra,
 			{
 				'wp-block-jetpack-layout-tablet': renderDeviceType === 'Tablet',
-				'wp-block-jetpack-layout-desktop': renderDeviceType === 'Desktop',
+				'wp-block-jetpack-layout-desktop':
+					renderDeviceType === 'Desktop',
 				'wp-block-jetpack-layout-mobile': renderDeviceType === 'Mobile',
 				'wp-block-jetpack-layout-resizable': this.canResizeBreakpoint(
 					renderDeviceType
@@ -247,7 +286,10 @@ class Edit extends Component {
 				<Placeholder
 					icon="layout"
 					label={ __( 'Choose Layout', 'layout-grid' ) }
-					instructions={ __( 'Select a layout to start with:', 'layout-grid' ) }
+					instructions={ __(
+						'Select a layout to start with:',
+						'layout-grid'
+					) }
 					className={ classes }
 				>
 					<ul className="block-editor-inner-blocks__template-picker-options">
@@ -255,8 +297,12 @@ class Edit extends Component {
 							<li key={ column.value }>
 								<IconButton
 									isSecondary
-									icon={ <ColumnIcon columns={ column.value } /> }
-									onClick={ () => this.onChangeLayout( column.value ) }
+									icon={
+										<ColumnIcon columns={ column.value } />
+									}
+									onClick={ () =>
+										this.onChangeLayout( column.value )
+									}
 									className="block-editor-inner-blocks__template-picker-option"
 									label={ column.label }
 								/>
@@ -271,10 +317,20 @@ class Edit extends Component {
 			<ToggleControl
 				label={ __( 'Add end gutters', 'layout-grid' ) }
 				help={
-					addGutterEnds ? __( 'Toggle off to remove the spacing left and right of the grid.', 'layout-grid' ) : __( 'Toggle on to add space left and right of the layout grid. ', 'layout-grid' )
+					addGutterEnds
+						? __(
+								'Toggle off to remove the spacing left and right of the grid.',
+								'layout-grid'
+						  )
+						: __(
+								'Toggle on to add space left and right of the layout grid. ',
+								'layout-grid'
+						  )
 				}
 				checked={ addGutterEnds }
-				onChange={ newValue => setAttributes( { addGutterEnds: newValue } )  }
+				onChange={ ( newValue ) =>
+					setAttributes( { addGutterEnds: newValue } )
+				}
 			/>
 		);
 
@@ -288,8 +344,18 @@ class Edit extends Component {
 						layoutGrid={ layoutGrid }
 						isSelected={ isSelected }
 					>
-						<div className="wpcom-overlay-grid" ref={ this.overlayRef }>
-							{ times( getGridWidth( renderDeviceType ) ).map( ( item ) => <div className="wpcom-overlay-grid__column" key={ item }></div> ) }
+						<div
+							className="wpcom-overlay-grid"
+							ref={ this.overlayRef }
+						>
+							{ times( getGridWidth( renderDeviceType ) ).map(
+								( item ) => (
+									<div
+										className="wpcom-overlay-grid__column"
+										key={ item }
+									></div>
+								)
+							) }
 						</div>
 
 						<InnerBlocks
@@ -305,15 +371,27 @@ class Edit extends Component {
 										<div
 											key={ column.value }
 											className={ classnames(
-												'block-editor-block-styles__item', {
-													'is-active': columns === column.value,
+												'block-editor-block-styles__item',
+												{
+													'is-active':
+														columns ===
+														column.value,
 												}
 											) }
-											onClick={ () => this.onChangeLayout( column.value ) }
+											onClick={ () =>
+												this.onChangeLayout(
+													column.value
+												)
+											}
 											onKeyDown={ ( event ) => {
-												if ( ENTER === event.keyCode || SPACE === event.keyCode ) {
+												if (
+													ENTER === event.keyCode ||
+													SPACE === event.keyCode
+												) {
 													event.preventDefault();
-													this.onChangeLayout( column.value );
+													this.onChangeLayout(
+														column.value
+													);
 												}
 											} }
 											role="button"
@@ -321,7 +399,9 @@ class Edit extends Component {
 											aria-label={ column.label }
 										>
 											<div className="block-editor-block-styles__item-preview">
-												<ColumnIcon columns={ column.value } />
+												<ColumnIcon
+													columns={ column.value }
+												/>
 											</div>
 											<div className="editor-block-styles__item-label block-editor-block-styles__item-label">
 												{ column.label }
@@ -330,24 +410,54 @@ class Edit extends Component {
 									) ) }
 								</div>
 
-								<p><em>{ __( 'Changing the number of columns will reset your layout and could remove content.', 'layout-grid' ) }</em></p>
+								<p>
+									<em>
+										{ __(
+											'Changing the number of columns will reset your layout and could remove content.',
+											'layout-grid'
+										) }
+									</em>
+								</p>
 							</PanelBody>
 
-							<PanelBody title={ __( 'Responsive Breakpoints', 'layout-grid' ) }>
-								<p><em>{ __( "Note that previewing your post will show your browser's breakpoint, not the currently selected one.", 'layout-grid' ) }</em></p>
+							<PanelBody
+								title={ __(
+									'Responsive Breakpoints',
+									'layout-grid'
+								) }
+							>
+								<p>
+									<em>
+										{ __(
+											"Note that previewing your post will show your browser's breakpoint, not the currently selected one.",
+											'layout-grid'
+										) }
+									</em>
+								</p>
 								<ButtonGroup>
 									{ getLayouts().map( ( layout ) => (
 										<Button
 											key={ layout.value }
-											isPrimary={ layout.value === selectedPreviewDevice }
-											onClick={ () => this.setPreviewDeviceType( layout.value ) }
+											isPrimary={
+												layout.value ===
+												selectedPreviewDevice
+											}
+											onClick={ () =>
+												this.setPreviewDeviceType(
+													layout.value
+												)
+											}
 										>
 											{ layout.label }
 										</Button>
 									) ) }
 								</ButtonGroup>
 
-								{ this.renderDeviceSettings( columns, selectedPreviewDevice, attributes ) }
+								{ this.renderDeviceSettings(
+									columns,
+									selectedPreviewDevice,
+									attributes
+								) }
 							</PanelBody>
 
 							<PanelBody title={ __( 'Gutter', 'layout-grid' ) }>
@@ -355,16 +465,23 @@ class Edit extends Component {
 
 								<SelectControl
 									value={ gutterSize }
-									onChange={ newValue => setAttributes( { gutterSize: newValue, addGutterEnds: newValue === 'none' ? false : addGutterEnds } ) }
+									onChange={ ( newValue ) =>
+										setAttributes( {
+											gutterSize: newValue,
+											addGutterEnds:
+												newValue === 'none'
+													? false
+													: addGutterEnds,
+										} )
+									}
 									options={ getGutterValues() }
 								/>
 
 								{ gutterSize === 'none' ? (
-									<Disabled>
-										{ toggleControl }
-									</Disabled>
-								) : toggleControl }
-
+									<Disabled>{ toggleControl }</Disabled>
+								) : (
+									toggleControl
+								) }
 							</PanelBody>
 						</InspectorControls>
 					</ResizeGrid>
@@ -381,7 +498,13 @@ class Edit extends Component {
 								<Button
 									aria-expanded={ isOpen }
 									onClick={ onToggle }
-									icon={ getLayouts().find( ( layout ) => layout.value === selectedPreviewDevice ).icon }
+									icon={
+										getLayouts().find(
+											( layout ) =>
+												layout.value ===
+												selectedPreviewDevice
+										).icon
+									}
 								/>
 							</ToolbarGroup>
 						) }
@@ -390,8 +513,15 @@ class Edit extends Component {
 								{ getLayouts().map( ( layout ) => (
 									<MenuItem
 										key={ layout.value }
-										isSelected={ layout.value === selectedPreviewDevice }
-										onClick={ () => this.setPreviewDeviceType( layout.value ) }
+										isSelected={
+											layout.value ===
+											selectedPreviewDevice
+										}
+										onClick={ () =>
+											this.setPreviewDeviceType(
+												layout.value
+											)
+										}
 										icon={ layout.icon }
 									>
 										{ layout.label }
@@ -411,7 +541,9 @@ function getColumnBlocks( currentBlocks, previous, columns ) {
 		// Add new blocks to the end
 		return [
 			...currentBlocks,
-			...times( columns - previous, () => createBlock( 'jetpack/layout-grid-column' ) ),
+			...times( columns - previous, () =>
+				createBlock( 'jetpack/layout-grid-column' )
+			),
 		];
 	}
 
@@ -424,7 +556,10 @@ function getColumnBlocks( currentBlocks, previous, columns ) {
 
 	// Remove empty blocks
 	cleanedBlocks = cleanedBlocks.filter( ( block ) => {
-		if ( totalRemoved < previous - columns && block.innerBlocks.length === 0 ) {
+		if (
+			totalRemoved < previous - columns &&
+			block.innerBlocks.length === 0
+		) {
 			totalRemoved++;
 			return false;
 		}
@@ -467,32 +602,44 @@ export default compose( [
 			const { clientId } = ownProps;
 			const { replaceBlock } = dispatch( 'core/block-editor' );
 			const { getBlocks } = registry.select( 'core/block-editor' );
-			const innerBlocks = getColumnBlocks( getBlocks( clientId ), previous, columns );
+			const innerBlocks = getColumnBlocks(
+				getBlocks( clientId ),
+				previous,
+				columns
+			);
 
 			// Replace the whole block with a new one so that our changes to both the attributes and innerBlocks are atomic
 			// This ensures that the undo history has a single entry, preventing traversing to a 'half way' point where innerBlocks are changed
 			// but the column attributes arent
-			const blockCopy = createBlock( ownProps.name, {
-				...ownProps.attributes,
-				...columnValues,
-				className: removeGridClasses( ownProps.attributes.className ),
-			}, innerBlocks );
+			const blockCopy = createBlock(
+				ownProps.name,
+				{
+					...ownProps.attributes,
+					...columnValues,
+					className: removeGridClasses(
+						ownProps.attributes.className
+					),
+				},
+				innerBlocks
+			);
 
 			replaceBlock( clientId, blockCopy );
 		},
 		setPreviewDeviceType( type ) {
-			const {
-				__experimentalSetPreviewDeviceType,
-			} = dispatch( 'core/edit-post' );
+			const { __experimentalSetPreviewDeviceType } = dispatch(
+				'core/edit-post'
+			);
 
 			__experimentalSetPreviewDeviceType( type );
-		}
+		},
 	} ) ),
 	withSelect( ( select, { clientId } ) => {
 		const { getBlockOrder, getBlockCount, getBlocksByClientId } = select(
 			'core/block-editor'
 		);
-		const { __experimentalGetPreviewDeviceType = null } = select( 'core/edit-post' );
+		const { __experimentalGetPreviewDeviceType = null } = select(
+			'core/edit-post'
+		);
 
 		return {
 			columns: getBlockCount( clientId ),

--- a/blocks/layout-grid/src/grid/edit.js
+++ b/blocks/layout-grid/src/grid/edit.js
@@ -56,7 +56,6 @@ import { getGridWidth, getDefaultSpan } from './grid-defaults';
 import ResizeGrid from './resize-grid';
 import LayoutGrid from './layout-grid';
 import PreviewDevice from './preview-device';
-import { desktop, grid, mobile } from '@wordpress/icons/build-types';
 
 const ALLOWED_BLOCKS = [ 'jetpack/layout-grid-column' ];
 const MINIMUM_RESIZE_SIZE = 50; // Empirically determined to be a good size

--- a/blocks/layout-grid/src/grid/edit.js
+++ b/blocks/layout-grid/src/grid/edit.js
@@ -330,7 +330,7 @@ class Edit extends Component {
 					updateViewport={ ( newPort ) =>
 						this.setState( {
 							viewPort: newPort,
-							inspectorDeviceType: previewDeviceType,
+							inspectorDeviceType: newPort,
 						} )
 					}
 				/>
@@ -454,7 +454,7 @@ class Edit extends Component {
 
 								{ this.renderDeviceSettings(
 									columns,
-									previewDeviceType,
+									inspectorDeviceType,
 									attributes
 								) }
 							</PanelBody>

--- a/blocks/layout-grid/src/grid/edit.js
+++ b/blocks/layout-grid/src/grid/edit.js
@@ -58,7 +58,7 @@ import LayoutGrid from './layout-grid';
 const ALLOWED_BLOCKS = [ 'jetpack/layout-grid-column' ];
 const MINIMUM_RESIZE_SIZE = 50; // Empirically determined to be a good size
 
-/** 
+/**
  * get the width of the editor, taking into account preview mode.
  */
 function getEditorDeviceWidth() {
@@ -73,17 +73,15 @@ function getEditorDeviceWidth() {
 	}
 }
 
-// Note this uses __experimentalGetPreviewDeviceType, but has a fallback for older versions of Gutenberg.
-// The fallback will be removed once WordPress contains supports for __experimentalGetPreviewDeviceType
 class Edit extends Component {
 	constructor( props ) {
 		super( props );
 
 		this.overlayRef = createRef();
 		this.state = {
-			selectedPreviewDeviceType: getLayouts()[ 0 ].value,
 			renderDeviceType: getEditorDeviceWidth(),
 		};
+
 		window.addEventListener( 'resize', this.onResizeWindow.bind( this ) );
 	}
 
@@ -105,26 +103,12 @@ class Edit extends Component {
 		this.props.updateColumns( this.props.columns, columns, columnValues );
 	};
 
-	getPreviewDeviceType() {
-		return this.props.previewDeviceType
-			? this.props.previewDeviceType
-			: this.state.selectedPreviewDeviceType;
-	}
-
-	setPreviewDeviceType = ( previewDeviceType ) => {
-		if ( this.props.previewDeviceType ) {
-			this.props.setPreviewDeviceType( previewDeviceType );
-		} else {
-			this.setState( { selectedPreviewDeviceType: previewDeviceType } );
-		}
-	};
-
 	updateRenderDeviceType = () => {
 		const renderDeviceType = getEditorDeviceWidth();
-		this.setState( {
-			renderDeviceType: renderDeviceType
-		} );
 
+		this.setState( {
+			renderDeviceType,
+		} );
 	};
 
 	componentDidUpdate = ( prevProps ) => {
@@ -234,7 +218,7 @@ class Edit extends Component {
 			columnAttributes,
 		} = this.props;
 		const renderDeviceType = this.state.renderDeviceType;
-		const selectedPreviewDevice = this.getPreviewDeviceType();
+		const selectedPreviewDevice = this.props.previewDeviceType;
 		const extra = getAsEditorCSS(
 			renderDeviceType,
 			columns,
@@ -516,7 +500,7 @@ export default compose( [
 				( innerBlockClientId ) =>
 					getBlocksByClientId( innerBlockClientId )[ 0 ].attributes
 			),
-			previewDeviceType: __experimentalGetPreviewDeviceType ? __experimentalGetPreviewDeviceType() : null,
+			previewDeviceType: __experimentalGetPreviewDeviceType(),
 		};
 	} ),
 ] )( Edit );

--- a/blocks/layout-grid/src/grid/preview-device.js
+++ b/blocks/layout-grid/src/grid/preview-device.js
@@ -9,7 +9,7 @@ import {
 	Button,
 	ToolbarGroup,
 	MenuGroup,
-	MenuItem,
+	MenuItemsChoice,
 	Dropdown,
 } from '@wordpress/components';
 import { BlockControls } from '@wordpress/block-editor';
@@ -77,20 +77,13 @@ function PreviewDevice( props ) {
 						) }
 						renderContent={ () => (
 							<MenuGroup>
-								{ getLayouts().map( ( layout ) => (
-									<MenuItem
-										key={ layout.value }
-										isSelected={
-											layout.value === previewDevice
-										}
-										onClick={ () =>
-											setPreviewDevice( layout.value )
-										}
-										icon={ layout.icon }
-									>
-										{ layout.label }
-									</MenuItem>
-								) ) }
+								<MenuItemsChoice
+									value={ previewDevice }
+									onSelect={ ( mode ) =>
+										setPreviewDevice( mode )
+									}
+									choices={ getLayouts() }
+								/>
 							</MenuGroup>
 						) }
 					/>

--- a/blocks/layout-grid/src/grid/preview-device.js
+++ b/blocks/layout-grid/src/grid/preview-device.js
@@ -100,5 +100,4 @@ function PreviewDevice( props ) {
 	);
 }
 
-//MyMobileComponent = ifViewportMatches( '< small' )( MyMobileComponent );
 export default PreviewDevice;

--- a/blocks/layout-grid/src/grid/preview-device.js
+++ b/blocks/layout-grid/src/grid/preview-device.js
@@ -1,0 +1,104 @@
+/**
+ * WordPress dependencies
+ */
+
+import { useEffect } from '@wordpress/element';
+import { useViewportMatch, useResizeObserver } from '@wordpress/compose';
+import { useSelect, useDispatch } from '@wordpress/data';
+import {
+	Button,
+	ToolbarGroup,
+	MenuGroup,
+	MenuItem,
+	Dropdown,
+} from '@wordpress/components';
+import { BlockControls } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+
+import { getLayouts } from '../constants';
+
+function getCurrentViewport( isMobile, isTablet ) {
+	if ( isMobile ) {
+		return 'Mobile';
+	}
+
+	if ( isTablet ) {
+		return 'Tablet';
+	}
+
+	return 'Desktop';
+}
+
+function PreviewDevice( props ) {
+	const { viewPort, updateViewport } = props;
+	const {
+		__experimentalSetPreviewDeviceType: setPreviewDevice,
+	} = useDispatch( 'core/edit-post' );
+	const previewDevice = useSelect(
+		( select ) =>
+			select( 'core/edit-post' ).__experimentalGetPreviewDeviceType(),
+		[]
+	);
+	const [ resizeListener, sizes ] = useResizeObserver();
+	const isTablet = useViewportMatch( 'medium', '<' );
+	const isMobile = useViewportMatch( 'small', '<' );
+
+	useEffect( () => {
+		const newPort = getCurrentViewport( isMobile, isTablet );
+
+		if ( newPort !== viewPort ) {
+			updateViewport( newPort );
+		}
+	}, [ sizes ] );
+
+	return (
+		<>
+			{ resizeListener }
+
+			{ ! isMobile && (
+				<BlockControls>
+					<Dropdown
+						renderToggle={ ( { isOpen, onToggle } ) => (
+							<ToolbarGroup>
+								<Button
+									aria-expanded={ isOpen }
+									onClick={ onToggle }
+									icon={
+										getLayouts().find(
+											( layout ) =>
+												layout.value === previewDevice
+										).icon
+									}
+								/>
+							</ToolbarGroup>
+						) }
+						renderContent={ () => (
+							<MenuGroup>
+								{ getLayouts().map( ( layout ) => (
+									<MenuItem
+										key={ layout.value }
+										isSelected={
+											layout.value === previewDevice
+										}
+										onClick={ () =>
+											setPreviewDevice( layout.value )
+										}
+										icon={ layout.icon }
+									>
+										{ layout.label }
+									</MenuItem>
+								) ) }
+							</MenuGroup>
+						) }
+					/>
+				</BlockControls>
+			) }
+		</>
+	);
+}
+
+//MyMobileComponent = ifViewportMatches( '< small' )( MyMobileComponent );
+export default PreviewDevice;

--- a/bundler/bundles/layout-grid.json
+++ b/bundler/bundles/layout-grid.json
@@ -2,7 +2,7 @@
 	"blocks": [
 		"layout-grid"
 	],
-	"version": "1.4",
+	"version": "1.5",
 	"name": "Layout Grid",
 	"description": "Let any blocks align to a global grid",
 	"resource": "jetpack-layout-grid",

--- a/bundler/resources/jetpack-layout-grid/readme.txt
+++ b/bundler/resources/jetpack-layout-grid/readme.txt
@@ -1,8 +1,8 @@
 === Layout Grid Block ===
 Contributors: automattic, jasmussen, johnny5, mkaz
-Stable tag: 1.4
+Stable tag: trunk
 Tested up to: 5.6
-Requires at least: 5.5
+Requires at least: 5.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Tags: blocks, layout, grid, design
@@ -23,6 +23,9 @@ You can follow development, file an issue, suggest features, and view the source
 2. Three column grid with resize handles.
 
 == Changelog ==
+
+= 1.5 - 5th February 2021 =
+* Improve editor responsive behaviour on smaller devices
 
 = 1.4 - 15th January 2021 =
 * Use hyphenation for text inside a grid column


### PR DESCRIPTION
Currently, when opening the editor on mobile, the layout grid is rendered in desktop mode.
its display is controlled by the `__experimentalGetPreviewDeviceType` property which can be set via gutenberg's preview mode, or through the block settings for the layout grid block. `__experimentalGetPreviewDeviceType` always defaults to desktop, so the layout grid always attmepts to render with maximum columns in the editor. This leads to "broken" looking pages in the mobile editor.
<img src="https://user-images.githubusercontent.com/22446385/102300152-1a178b80-3fa0-11eb-9fa5-6329d47f8f42.jpeg" width="300"/>

### Context
Initial report
https://github.com/Automattic/wp-calypso/issues/42148

More discussion and investigation
https://github.com/Automattic/block-experiments/issues/152

### Code changes and proposal
#### Goals
My aim was to keep the "Preview Mode" functionality working as it is while also supporting  editing on mobile intuitively.

#### Approach
I split the device detection into the "preview mode" represented by `selectedPreviewDeviceType` and the "rendering mode" represented by `renderDeviceType`. The preview mode remains based on the `__experimentalGetPreviewDeviceType` flag from `core/block-editor` while the render mode is based solely on the width of the "visual editor".

<img width="851" alt="Screen Shot 2020-12-16 at 1 16 25 PM" src="https://user-images.githubusercontent.com/22446385/102300778-44b61400-3fa1-11eb-9771-da5fd7f01ed1.png">

When the preview mode is changed, or the window is resized, the rendering mode is recomputed. The result is quite intuitive I think!

![Dec-16-2020 12-34-49](https://user-images.githubusercontent.com/22446385/102300898-85159200-3fa1-11eb-94d6-3cf361b870da.gif)

### Test instructions

* Sync this change to block experiments to your wordpress install or sandbox
* Add a layout grid to the editor
* Play with the preview mode, it can be changed via an icon when the block is selected, via the block settings, or via a page level preview dropdown (last option isn't available on wpcom)
* Play with the screen size, the number of columns should adjust intuitively
* What edge cases or interactions have I missed?

