### PR TITLE
Try: Fix firefox boundary issue.

### DIFF
--- a/blocks/layout-grid/front.css
+++ b/blocks/layout-grid/front.css
@@ -1043,9 +1043,5 @@
   .wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__huge {
     grid-gap: 48px; }
 
-@-moz-document url-prefix() {
-  .wp-block-jetpack-layout-grid .wp-block-cover {
-    max-height: 0; } }
-
 .wp-block-jetpack-layout-grid-column {
   max-width: 100%; }

--- a/blocks/layout-grid/front.scss
+++ b/blocks/layout-grid/front.scss
@@ -124,13 +124,6 @@
 	&.wp-block-jetpack-layout-gutter__huge {
 		grid-gap: $grid-gutter-huge;
 	}
-
-	// Fixes an issue in Firefox where a block in the grid with 100% height causes the grid to increase in height
-	@-moz-document url-prefix() {
-		.wp-block-cover {
-			max-height: 0;
-		}
-	}
 }
 
 // Ensure inner blocks with deliberate overflows are still constrained to column.


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/47247, hopefully with no side effects.

It effectively removes the fix we added in https://github.com/Automattic/block-experiments/pull/38, and it seems to work for me. Editor:

<img width="1215" alt="Screenshot 2021-03-04 at 10 22 47" src="https://user-images.githubusercontent.com/1204802/109941837-d9dcc500-7cd3-11eb-8659-e60802ecb44c.png">

Frontend:

<img width="1057" alt="Screenshot 2021-03-04 at 10 23 24" src="https://user-images.githubusercontent.com/1204802/109941844-dcd7b580-7cd3-11eb-82d0-82fa8eb36376.png">

However it's important we test this in Firefox thoroughly so we don't regress the initial issue.