### PR TITLE
Remove hyphenation.

### DIFF
--- a/blocks/layout-grid/front.css
+++ b/blocks/layout-grid/front.css
@@ -1030,10 +1030,7 @@
             grid-row-start: 4; } }
   .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column * {
     word-break: break-word;
-    word-wrap: break-word;
-    -webkit-hyphens: auto;
-        -ms-hyphens: auto;
-            hyphens: auto; }
+    word-wrap: break-word; }
   .wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__none {
     grid-gap: 0px; }
   .wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__small {

--- a/blocks/layout-grid/front.scss
+++ b/blocks/layout-grid/front.scss
@@ -106,7 +106,6 @@
 	.wp-block-jetpack-layout-grid-column * {
 		word-break: break-word;
 		word-wrap: break-word;
-		hyphens: auto;
 	}
 
 	&.wp-block-jetpack-layout-gutter__none {

--- a/blocks/layout-grid/src/grid.scss
+++ b/blocks/layout-grid/src/grid.scss
@@ -30,7 +30,6 @@
 	// Prevent long unbroken words from overflowing.
 	word-break: break-word; // For back-compat.
 	overflow-wrap: break-word; // New standard.
-	hyphens: auto;
 }
 
 .wp-block-jetpack-layout-grid.wp-block-jetpack-layout-gutter__none > .block-editor-inner-blocks > .block-editor-block-list__layout {


### PR DESCRIPTION
Fixes #173, but undoes the fix we used to close #155. 

Text wraps so as to not break the layout, see https://github.com/Automattic/block-experiments/issues/173#issuecomment-790529713.

However hyphenation has not been popular. This PR removes it again. 