### PR TITLE
Explicitly set the background color of resize handles.

### DIFF
--- a/blocks/layout-grid/editor.scss
+++ b/blocks/layout-grid/editor.scss
@@ -167,6 +167,10 @@
 			top: 50%;
 			transform: translateY(-50%);
 			right: calc(50% - 4px);
+
+			// Explicitly set the background color.
+			background: #007cba;
+			background: var(--wp-admin-theme-color);
 		}
 
 		// Adjust the vertical separator.


### PR DESCRIPTION
In Gutenberg core, the resize handle background color looks to be changing in https://github.com/WordPress/gutenberg/pull/30339. 

When that happens, the resize handle will become white in Layout Grid:

<img width="965" alt="Screenshot 2021-03-29 at 13 57 11" src="https://user-images.githubusercontent.com/1204802/112835193-45c70900-9099-11eb-8e49-c35f371ea71b.png">

This PR explicitly sets the color, so it works both in current contexts, and future contexts:

<img width="1163" alt="Screenshot 2021-03-29 at 14 13 56" src="https://user-images.githubusercontent.com/1204802/112835248-4f507100-9099-11eb-8afa-78e5d9892136.png">

There's an obscure edgecase built in, where if your browser does not support CSS variables, and you use a wp-admin theme other than the default one, you'll see WordPress blue drag handles. Seems a fine tradeoff.

An alternative is we can drop the customized resize handles in favor of the vanilla ones. 