### PR TITLE
Layout Grid: Use desktop layout when rendering within a pattern preview (e.g. within a Disabled context)

### DIFF
--- a/blocks/layout-grid/src/grid/edit.js
+++ b/blocks/layout-grid/src/grid/edit.js
@@ -211,6 +211,11 @@ class Edit extends Component {
 	}
 
 	getPreviewMode() {
+		// If we're rendering within a pattern preview, use the desktop layout for the preview.
+		if ( this.props.isBlockOrPatternPreview ) {
+			return 'Desktop';
+		}
+
 		// If we're on desktop, or the preview is set to mobile, then return the preview mode
 		if (
 			this.state.viewPort === 'Desktop' ||
@@ -527,6 +532,18 @@ function getColumnBlocks( currentBlocks, previous, columns ) {
 		.reverse();
 }
 
+function MaybeDisabledEdit( props ) {
+	return (
+		<Disabled.Consumer>
+			{ ( isDisabled ) => {
+				return (
+					<Edit { ...props } isBlockOrPatternPreview={ isDisabled } />
+				);
+			} }
+		</Disabled.Consumer>
+	);
+}
+
 export default compose( [
 	withDispatch( ( dispatch, ownProps, registry ) => ( {
 		/**
@@ -604,4 +621,4 @@ export default compose( [
 			previewDeviceType: __experimentalGetPreviewDeviceType(),
 		};
 	} ),
-] )( Edit );
+] )( MaybeDisabledEdit );


### PR DESCRIPTION
Related to: 234-gh-Automattic/view-design

This change adds a HOC to load in the Disabled context for the Layout Grid to determine whether or not we are rendering within a block pattern preview. If we are, then let's render using the desktop layout, to prevent very long vertical pattern previews (see: 234-gh-Automattic/view-design)

After this change, the block pattern preview will render using the Desktop layout when you're using a mobile viewport, however once you insert the pattern, you will be _editing_ using the mobile viewport, so that 🤞 we get the best of both worlds.

| Mobile | Desktop |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/112944502-a5e3ab00-917e-11eb-87e7-a02f1fa813f8.png) | ![image](https://user-images.githubusercontent.com/14988353/112944517-ac722280-917e-11eb-8cf4-150f24e8afe7.png) |

How to test:

Testing this with the wpcom patterns is a little tricky, but I managed to get it working using a8c-wp-env (loading the ETK plugin and Block Experiments, and then going to the Plugins to install Gutenberg), and then adding the following line to `block-experiments.php` so that we switch on loading the wpcom patterns for testing:

```
add_filter( 'a8c_enable_block_patterns_api', '__return_true' );
```

I also needed to run `npm build` in the block experiments directory to get this running.

Once your local development environment is running this change correctly, test the following:

1. When in a desktop viewport, open up the pattern inserter and the first pattern under Featured should be rendered using the Desktop layout within the pattern preview. When you insert the pattern, it should still be in the Desktop layout.
2. Using a mobile viewport (e.g. narrow your browser window), when you open up the pattern inserter, the first pattern under Featured should still be rendered using the Desktop layout within the pattern preview. However, when you insert it, it should now use the mobile layout while you're editing your post or page.