### PR TITLE
Try: Padding fix.

### DIFF
--- a/blocks/layout-grid/style.scss
+++ b/blocks/layout-grid/style.scss
@@ -10,7 +10,7 @@
  */
 
 /* autoprefixer grid: no-autoplace */
-
+.wp-block-jetpack-layout-grid-editor,
 .wp-block-jetpack-layout-grid {
 	// This padding adds end gutters.
 	padding-left: 24px;
@@ -92,6 +92,7 @@
  * Individual Column Options
  */
 
+.wp-block-jetpack-layout-grid-editor .wp-block-jetpack-layout-grid-column,
 .wp-block-jetpack-layout-grid .wp-block-jetpack-layout-grid-column {
 	// When a column has a background color, we add negative margins to enable
 	// some of the gutter to work as default padding.


### PR DESCRIPTION
https://github.com/Automattic/block-experiments/pull/177 retired the front only stylesheet.

It also changed `.wp-block-jetpack-layout-grid` to `.wp-block-jetpack-layout-grid-editor`, in the editor only. Which appears to have caused some issues with custom column paddings, and grid end gutters as well.

This PR does fix that:

![patch](https://user-images.githubusercontent.com/1204802/114389541-68771880-9b95-11eb-8d30-8ea08519a1a5.gif)

However I'm not sure this is the way we should fix it. In part also because I'm not entirely sure _why_ it fixes it. A better fix might be to not rename that class in the first place. 