### PR TITLE
Try: Safari grid visibility fix.

### DIFF
--- a/blocks/layout-grid/editor.scss
+++ b/blocks/layout-grid/editor.scss
@@ -217,7 +217,10 @@
 /**
  * Individual column alignment for the editor
  */
+
 .wp-block-jetpack-layout-grid-editor {
+	position: relative;
+
 	&.are-vertically-aligned-top [data-type="jetpack/layout-grid-column"].wp-block {
 		align-self: flex-start;
 	}

--- a/blocks/layout-grid/src/grid-overlay.scss
+++ b/blocks/layout-grid/src/grid-overlay.scss
@@ -20,16 +20,24 @@
 	left: 0;
 	bottom: 0;
 	right: 0;
-	display: grid;
-	grid-gap: $grid-gutter;
-	grid-template-columns: $grid-desktop;
 
-	// This padding adds end gutters.
-	padding-left: $grid-gutter;
-	padding-right: $grid-gutter;
+	> .wpcom-overlay-grid__inner {
+		top: 0;
+		left: 0;
+		bottom: 0;
+		right: 0;
+		display: grid;
+		grid-gap: $grid-gutter;
+		grid-template-columns: $grid-desktop;
+		height: 100%;
 
-	// Lower the z-index so it's under the block borders.
-	z-index: 0;
+		// This padding adds end gutters.
+		padding-left: $grid-gutter;
+		padding-right: $grid-gutter;
+
+		// Lower the z-index so it's under the block borders.
+		z-index: 0;
+	}
 
 	// Colorize for dark themes also.
 	color: rgba(0,0,0,0.03);

--- a/blocks/layout-grid/src/grid/edit.js
+++ b/blocks/layout-grid/src/grid/edit.js
@@ -350,14 +350,16 @@ class Edit extends Component {
 					isSelected={ isSelected }
 				>
 					<div className="wpcom-overlay-grid" ref={ this.overlayRef }>
-						{ times( getGridWidth( previewMode ) ).map(
-							( item ) => (
-								<div
-									className="wpcom-overlay-grid__column"
-									key={ item }
-								></div>
-							)
-						) }
+						<div className="wpcom-overlay-grid__inner">
+							{ times( getGridWidth( previewMode ) ).map(
+								( item ) => (
+									<div
+										className="wpcom-overlay-grid__column"
+										key={ item }
+									></div>
+								)
+							) }
+						</div>
 					</div>
 
 					<InnerBlocks

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,6 @@ setCategories( [
  * Load all our blocks
  */
 import * as bauhausCentenaryBlock from '../blocks/bauhaus-centenary/src';
-import * as duotoneFilter from '../blocks/duotone-filter/src';
 import * as eventBlock from '../blocks/event/src';
 import * as layoutGridBlock from '../blocks/layout-grid/src';
 import * as motionBackgroundBlock from '../blocks/motion-background/src';
@@ -33,7 +32,6 @@ import * as bookBlock from '../blocks/book/src';
 
 // Instantiate the blocks, adding them to our block category
 bauhausCentenaryBlock.registerBlock();
-duotoneFilter.registerBlock();
 eventBlock.registerBlock();
 layoutGridBlock.registerBlock();
 motionBackgroundBlock.registerBlock();


### PR DESCRIPTION
Fixes a column visibility issue in Safari:

Before:

<img src="https://user-images.githubusercontent.com/1204802/119482905-b1a1b700-bd54-11eb-9df9-a4eb435545d6.gif">

After:

![safari fix](https://user-images.githubusercontent.com/1204802/119486279-5ec9fe80-bd58-11eb-9f9b-7be3442e22fd.gif)

It MIGHT also fix an issue in #194. But probably not.

I have a better understanding of why the issue is as is. Turns out it's because Safari has a different interpretation of CSS grid heights. 100% is a relative unit, but relative of what? To my best understanding, when a grid container has 100% height and is the child of a grid container, it's relative to an ancestor. This PR adds a non grid container wrapper, which makes it possible for the grid container inside of that to be relative to its non grid parent.

Test the grid in Safari, see that it all works.