### PR TITLE
Fix the CSS being broken on first starting dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"license": "GPL-2.0-or-later",
 	"scripts": {
 		"env": "wp-env",
-		"start": "yarn build-css && wp-scripts start & node-sass --watch editor.scss -o build & node-sass --watch style.scss -o build",
+		"start": "yarn build-css & wp-scripts start & node-sass --watch editor.scss -o build & node-sass --watch style.scss -o build",
 		"build": "wp-scripts build && yarn build-css",
 		"build-css": "node-sass ./editor.scss -o build | postcss build/editor.css -u autoprefixer -b 'last 2 versions' -r --no-map && node-sass ./style.scss -o build | postcss build/style.css -u autoprefixer -b 'last 2 versions' -r --no-map",
 		"plugin": "yarn clean && node ./bundler/build",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+const { CleanWebpackPlugin } = require( 'clean-webpack-plugin' );
+
+/**
+ * WordPress dependencies
+ */
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
+
+module.exports = {
+	...defaultConfig,
+
+	// Disable the clean plugin as it kills our CSS
+	plugins: defaultConfig.plugins.filter(
+		( plugin ) => ! ( plugin instanceof CleanWebpackPlugin )
+	),
+};


### PR DESCRIPTION
This really needs moving entirely to the @wordpress/scripts system, but it also involves a revamp of bundling a plugin and that's a bigger job.