### PR TITLE
Clean block styles from layout grid

### DIFF
--- a/blocks/layout-grid/src/grid/css-classname.js
+++ b/blocks/layout-grid/src/grid/css-classname.js
@@ -178,6 +178,7 @@ export function removeGridClasses( classes ) {
 		.replace( /\s{2,}/, '' )
 		.replace( /wp-block-jetpack-layout-gutter__\w*/, '' )
 		.replace( /is-vertically-aligned-\w*/, '' )
+		.replace( /is-style-[A-Za-z-_]*/, '' )
 		.replace( /are-vertically-aligned-\w*/ );
 }
 


### PR DESCRIPTION
Due to the way the grid block handles class names if you enabled a block style on the grid it would be difficult to then get rid of it. This cleans the style from the classes, which makes switching between them work properly.