### PR TITLE
RNative: Fix nested adding of the LayoutGrid Block

### DIFF
--- a/blocks/layout-grid/src/grid/edit.native.js
+++ b/blocks/layout-grid/src/grid/edit.native.js
@@ -54,6 +54,16 @@ function ColumnsEdit( {
 	const { verticalAlignment, align } = attributes;
 
 	const [ isDefaultColumns, setDefaultColumns ] = useState( ! columns );
+	if ( ! columns ) {
+		// Set the default column on the next tick.
+		// This is done so that the insertion doesn't conflict with removal Modal dismissal
+		// And we end up with a state where the VariationControl is set to be visible
+		// but not dismissible.
+		// eslint-disable-next-line @wordpress/react-no-unsafe-timeout
+		setTimeout( () => {
+			setDefaultColumns( true );
+		}, 0 );
+	}
 
 	const [ resizeListener, sizes ] = useResizeObserver();
 	const { width } = sizes || {};

--- a/blocks/layout-grid/src/grid/edit.native.js
+++ b/blocks/layout-grid/src/grid/edit.native.js
@@ -53,10 +53,12 @@ function ColumnsEdit( {
 } ) {
 	const { verticalAlignment, align } = attributes;
 
-	const [ isDefaultColumns, setDefaultColumns ] = useState( ! columns );
+	const [ isDefaultColumns, setDefaultColumns ] = useState( false );
 	if ( ! columns ) {
 		// Set the default column on the next tick.
-		// This is done so that the insertion doesn't conflict with removal Modal dismissal
+		// This is done so that the insertion of the Layout Grid Block inside other blocks
+		// such as thr group block or itself doesn't conflict with removal BlockPicker BottomSheet
+		// and the VariationControl BottomSheet.
 		// And we end up with a state where the VariationControl is set to be visible
 		// but not dismissible.
 		// eslint-disable-next-line @wordpress/react-no-unsafe-timeout


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/3581

This PR fixes the insertion of the layout grid block within other blocks that have inner blocks nested.  

# Screenshot (with fixes)

https://user-images.githubusercontent.com/115071/120932365-4d62e980-c6aa-11eb-85d1-611180c0b9d3.mp4



# How to test. 
Add the layout grid block within the group block.
1. Add the Group Block. 
2. Add the layout grid block within the layout grid block.
3. Add any block within the layout grid block as expected. 

Add the layout grid block within the layout grid block 
1. Add the Layout grid block 
2. Add the layout grid block within the layout grid block.
3. Add any block within the layout grid block as expected. 
4. Repeat. 


Add the layout grid block within the columns block 
1. Add the Layout grid block 
2. Add the layout grid block within the layout grid block.
3. Add any block within the layout grid block as expected. 
4. Repeat. 


