### PR TITLE
Update waves and starscape to deal with rename in core from __experimentalUseEditorFeature to useSetting

### DIFF
--- a/blocks/starscape/src/edit.js
+++ b/blocks/starscape/src/edit.js
@@ -13,7 +13,7 @@ import {
 	RichText,
 	withColors,
 	__experimentalPanelColorGradientSettings as PanelColorGradientSettings,
-	__experimentalUseEditorFeature as useEditorFeature,
+	useSetting,
 } from '@wordpress/block-editor';
 import { BaseControl, PanelBody, RangeControl } from '@wordpress/components';
 import { compose, withInstanceId } from '@wordpress/compose';
@@ -34,7 +34,7 @@ const Edit = ( {
 	setAttributes,
 	className,
 } ) => {
-	const themeColors = useEditorFeature( 'color.palette' ) || [];
+	const themeColors = useSetting( 'color.palette' ) || [];
 
 	return (
 		<>

--- a/blocks/waves/src/edit.js
+++ b/blocks/waves/src/edit.js
@@ -11,7 +11,7 @@ import {
 	PanelColorSettings,
 	InnerBlocks,
 	__experimentalUnitControl as UnitControl,
-	__experimentalUseEditorFeature as useEditorFeature,
+	useSetting,
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -104,7 +104,7 @@ function Edit( { attributes, className, isSelected, setAttributes } ) {
 	const [ temporaryMinHeight, setTemporaryMinHeight ] = useState( null );
 	const [ isResizing, setIsResizing ] = useState( false );
 
-	const colorPalette = useEditorFeature( 'color.palette' );
+	const colorPalette = useSetting( 'color.palette' );
 
 	const themeColors = colorPalette?.length
 		? colorPalette


### PR DESCRIPTION
Waves and Starscape have been relying on `__experimentalUseEditorFeature` to pick the registered colorPalette.

A recent update in Gutenberg has made that API official under the name `useSetting`.

#### Testing instructions

1. checkout this branch
2. Remove all dependencies (`rm -rf node_modules`)
3. Run npm run build
4. Run `npx wp-env start` to leverage the dev environment.
5. Add a starscape and wave block and expect them not to crash