### PR TITLE
Fix: RN Mobile layout grid appenderstyles

### DIFF
--- a/blocks/layout-grid/src/grid-column/edit.native.js
+++ b/blocks/layout-grid/src/grid-column/edit.native.js
@@ -11,6 +11,7 @@ import {
 	BottomSheetSelectControl,
 	alignmentHelpers,
 } from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
 import { withViewportMatch } from '@wordpress/viewport';
 import {
 	InnerBlocks,
@@ -118,6 +119,35 @@ function ColumnsEdit( {
 		viewportSize
 	);
 
+	const isFullWidthAppender =
+		calculatedColumnStyles.width === contentStyle.width &&
+		isFullWidth( parentAlign );
+
+	const renderAppender = useCallback( () => {
+		if ( isSelected ) {
+			return (
+				<View
+					style={ [
+						styles[ 'column__appender' ],
+						isFullWidthAppender &&
+							styles[ 'column__appender-full-width' ],
+						isFullWidthAppender &&
+							hasChildren &&
+							styles[
+								'column__appender-full-width-has-children'
+							],
+						! isFullWidthAppender &&
+							hasChildren &&
+							styles[ 'column__appender-not-full-width' ],
+					] }
+				>
+					<InnerBlocks.ButtonBlockAppender />
+				</View>
+			);
+		}
+		return null;
+	}, [ isFullWidthAppender, isSelected, hasChildren ] );
+
 	if ( ! isSelected && ! hasChildren ) {
 		return (
 			<View
@@ -135,35 +165,12 @@ function ColumnsEdit( {
 			? styles[ 'column__padding-none-is-selected' ]
 			: styles[ 'column__padding-' + padding ];
 
-	const appenderStyle = hasChildren
-		? styles[ 'column__appender-has-children' ]
-		: styles.column__appender;
-
 	return (
 		<>
 			<View style={ [ columnPadding, calculatedColumnStyles ] }>
 				<InnerBlocks
 					templateLock={ false }
-					renderAppender={
-						! hasChildren || isSelected
-							? () => (
-									<View
-										style={
-											isFullWidth( parentAlign )
-												? appenderStyle
-												: [
-														appenderStyle,
-														styles[
-															'column__appender-not-full-width'
-														],
-												  ]
-										}
-									>
-										<InnerBlocks.ButtonBlockAppender />
-									</View>
-							  )
-							: undefined
-					}
+					renderAppender={ renderAppender }
 					parentWidth={ calculatedColumnStyles.width }
 					blockWidth={ calculatedColumnStyles.width }
 				/>

--- a/blocks/layout-grid/src/grid-column/edit.native.scss
+++ b/blocks/layout-grid/src/grid-column/edit.native.scss
@@ -16,20 +16,26 @@
 }
 
 .column__appender {
-	margin-left: 8px;
-	margin-right: 8px;
-	margin-bottom: -10px; 
+	margin-left: $grid-unit-10;
+	margin-right: $grid-unit-10;
+	margin-bottom: -10px;
 }
 
-.column__appender-has-children {
-	margin-left: 16px;
-	margin-right: 16px;
-	margin-bottom: 6px; 
+.column__appender-full-width {
+	margin-left: $grid-unit * 2.5;
+	margin-right: $grid-unit * 2.5;
+}
+
+.column__appender-full-width-has-children {
+	margin-left: $grid-unit-15;
+	margin-right: $grid-unit-15;
+	margin-bottom: 5px;
 }
 
 .column__appender-not-full-width {
 	margin-left: 0;
 	margin-right: 0;
+	margin-bottom: 5px;
 }
 
 .column__padding-none {


### PR DESCRIPTION
Due to the refactor of inner blocks in https://github.com/WordPress/gutenberg/pull/32068 
We need to adjust the Appender styles so that they look not broken in the layout grid single column.

## Testing instructions

Add the layout grid to the editor. 
Make sure it looks as expected. 

Test the layout grid across divide widths.  ( Tablet, mobile rotate to different widths) also full width and non-full width.

The Appender Button should always look like a button.


Screenshots

<img width="300px" src="https://user-images.githubusercontent.com/115071/122814115-a0cb5f00-d288-11eb-9af6-8c70f8e72890.png" />

<img width="300px" src="https://user-images.githubusercontent.com/115071/122814165-afb21180-d288-11eb-9fda-68bc159529f5.png" />

<img width="300px" src="https://user-images.githubusercontent.com/115071/122814223-bfc9f100-d288-11eb-9fee-6ab5e67898a4.png" />

<img width="300px" src="https://user-images.githubusercontent.com/115071/122814181-b3de2f00-d288-11eb-8ce0-26436f79aa76.png" />

<img width="300px" src="https://user-images.githubusercontent.com/115071/122814295-d6704800-d288-11eb-9c80-cc033f4dbc44.png" />

<img width="300px" src="https://user-images.githubusercontent.com/115071/122814314-db34fc00-d288-11eb-9461-cb09fe53bc19.png" />

<img width="300px" src="https://user-images.githubusercontent.com/115071/122814390-f6a00700-d288-11eb-92a8-c751b126e1e4.png" />

<img width="300px" src="https://user-images.githubusercontent.com/115071/122814399-fa338e00-d288-11eb-8780-b571106f7191.png" />

