### PR TITLE
Update sketch block readme and bump to 1.0.2

### DIFF
--- a/bundler/resources/a8c-sketch/readme.txt
+++ b/bundler/resources/a8c-sketch/readme.txt
@@ -1,20 +1,24 @@
 === Sketch Block ===
 Contributors: automattic, matveb, oskosk, pablohoneyhoney
-Stable tag: 1.0.0
+Stable tag: 1.0.2
 Tested up to: 5.7.2
 Requires at least: 5.7
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Freehand sketching
+Sketch and draw freely on a canvas with brush strokes that feel natural.
 
 == Description ==
 
-Draw and write freely on a canvas. The block offers color selection, different brush sizes, and with its transparent background can be layered on top of any container block, like groups or covers.
+Sketch and draw freely on a canvas with brush strokes that feel natural. Pick among three different brush sizes and the color palette of the site. The block has a transparent background so it can be layered on top of any container block, like groups or background images to achieve different effects.
 
 ## Requirements
 
-As this is part of a series of block experiments, the latest version of the <a href="https://wordpress.org/plugins/gutenberg/">Gutenberg Plugin</a> is required.
+This is an initial beta release that requires the <a href="https://wordpress.org/plugins/gutenberg/">Gutenberg Plugin</a> to work.
+
+## Credits
+
+The block is powered by the awesome <a href="https://www.npmjs.com/package/perfect-freehand">perfect-freehand</a> library.
 
 ## Source and Support
 


### PR DESCRIPTION
I published som changes to the readme in https://wordpress.org/plugins/sketch .

I first tagged a 1.0.1 version in the wrong way. Then an 1.0.2.

This PR syncs back those changes