### PR TITLE
Update sketch block to have Tag: block, to have style, editorStyle, editorScript in block.json, and bump to 1.0.6

### DIFF
--- a/bundler/bundles/sketch.json
+++ b/bundler/bundles/sketch.json
@@ -1,6 +1,6 @@
 {
 	"blocks": [ "sketch" ],
-	"version": "1.0.4",
+	"version": "1.0.6",
 	"name": "Sketch",
 	"description": "Draw and write freely on a canvas. The block offers color selection, different brush sizes, and with its transparent background can be layered on top of any container block, like groups or covers.",
 	"resource": "a8c-sketch"

--- a/bundler/resources/a8c-sketch/block.json
+++ b/bundler/resources/a8c-sketch/block.json
@@ -2,5 +2,8 @@
 	"name": "a8c/sketch",
 	"title": "Sketch",
 	"description": "Draw and write freely on a canvas. The block offers color selection, different brush sizes, and with its transparent background can be layered on top of any container block, like groups or covers.",
-	"category": "widgets"
+	"category": "widgets",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./editor.css",
+	"style": "file:./style.css"
 }

--- a/bundler/resources/a8c-sketch/readme.txt
+++ b/bundler/resources/a8c-sketch/readme.txt
@@ -1,11 +1,11 @@
 === Sketch Block ===
 Contributors: automattic, matveb, oskosk, pablohoneyhoney
-Stable tag: 1.0.4
+Stable tag: 1.0.6
 Tested up to: 5.7.2
 Requires at least: 5.7
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
-Tags: blocks, sketch, freehand, drawing
+Tags: block, blocks, sketch, freehand, drawing
 
 Sketch and draw freely on a canvas with brush strokes that feel natural.
 


### PR DESCRIPTION
I published some changes to the readme in https://wordpress.org/plugins/sketch .

A 1.0.6 has been published to the directory.

This PR syncs back those changes