### PR TITLE
Address block discoverability issues in Bauhaus Centenary Block

### DIFF
--- a/bundler/bundles/bauhaus-centenary.json
+++ b/bundler/bundles/bauhaus-centenary.json
@@ -1,8 +1,6 @@
 {
-	"blocks": [
-		"bauhaus-centenary"
-	],
-	"version": "1.0.2",
+	"blocks": [ "bauhaus-centenary" ],
+	"version": "1.0.3",
 	"name": "Bauhaus Centenary",
 	"description": "Celebrate the centenary of the design school",
 	"resource": "a8c-bauhaus-centenary"

--- a/bundler/resources/a8c-bauhaus-centenary/block.json
+++ b/bundler/resources/a8c-bauhaus-centenary/block.json
@@ -2,5 +2,8 @@
 	"name": "a8c/bauhaus-centenary",
 	"title": "Bauhaus Centenary",
 	"description": "Celebrate the centenary of the design school.",
-	"category": "widgets"
+	"category": "widgets",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./editor.css",
+	"style": "file:./style.css"
 }

--- a/bundler/resources/a8c-bauhaus-centenary/readme.txt
+++ b/bundler/resources/a8c-bauhaus-centenary/readme.txt
@@ -1,10 +1,11 @@
 === Bauhaus Centenary Block ===
 Contributors: automattic, ajlende, pablohoneyhoney
-Stable tag: 1.0.2
+Stable tag: 1.0.3
 Tested up to: 5.6
 Requires at least: 5.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Tags: block, blocks, bauhaus
 
 Celebrate the centenary of the design school
 
@@ -15,7 +16,7 @@ Celebrate the centenary of the design school
 ## Requirements
 
 As this is part of a series of block experiments, the latest version of the <a href="https://wordpress.org/plugins/gutenberg/">Gutenberg Plugin</a> is required.
-  
+
 ## Source and Support
 
 You can follow development, file an issue, suggest features, and view the source at the Github repo: <a href="https://github.com/Automattic/block-experiments">https://github.com/Automattic/block-experiments</a>


### PR DESCRIPTION
* Adds tags `block`, `blocks` and bauhaus
* Adds keys `editorScript`, `editorStyle` and `style` to `block.json`
* Bumps version to 1.0.3