### PR TITLE
Address block discoverability issues in Waves Block

### DIFF
--- a/bundler/bundles/waves.json
+++ b/bundler/bundles/waves.json
@@ -1,6 +1,6 @@
 {
 	"blocks": [ "waves" ],
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"name": "Waves Block",
 	"description": "Blocks can now be sinuous and soothing with the Waves Block.",
 	"resource": "a8c-waves"

--- a/bundler/resources/a8c-waves/block.json
+++ b/bundler/resources/a8c-waves/block.json
@@ -2,5 +2,8 @@
 	"name": "a8c/waves",
 	"title": "Waves",
 	"description": "Blocks can now be sinuous and soothing with the Waves Block.",
-	"category": "widgets"
+	"category": "widgets",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./editor.css",
+	"style": "file:./style.css"
 }

--- a/bundler/resources/a8c-waves/readme.txt
+++ b/bundler/resources/a8c-waves/readme.txt
@@ -1,10 +1,11 @@
 === Waves Block ===
 Contributors: automattic, ajlende, pablohoneyhoney
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 Tested up to: 5.6
 Requires at least: 5.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Tags: block, blocks, waves
 
 Gradients in motion.
 


### PR DESCRIPTION
* Adds tags `block`, `blocks` and bauhaus
* Adds keys `editorScript`, `editorStyle` and `style` to `block.json`
* Bumps version to 1.0.2