### PR TITLE
Address block discoverability issues in Starscape Block

### DIFF
--- a/bundler/bundles/starscape.json
+++ b/bundler/bundles/starscape.json
@@ -1,8 +1,6 @@
 {
-	"blocks": [
-		"starscape"
-	],
-	"version": "1.0.2",
+	"blocks": [ "starscape" ],
+	"version": "1.0.3",
 	"name": "Starscape Block",
 	"description": "Stars in motion",
 	"resource": "a8c-starscape"

--- a/bundler/resources/a8c-starscape/block.json
+++ b/bundler/resources/a8c-starscape/block.json
@@ -2,5 +2,8 @@
 	"name": "a8c/starscape",
 	"title": "Starscape",
 	"description": "Everything was made of collapsing stars, we are all made of star stuff. Now we also can create content in WordPress with stars in motion.",
-	"category": "widgets"
+	"category": "widgets",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./editor.css",
+	"style": "file:./style.css"
 }

--- a/bundler/resources/a8c-starscape/readme.txt
+++ b/bundler/resources/a8c-starscape/readme.txt
@@ -1,10 +1,11 @@
 === Starscape Block ===
 Contributors: automattic, ajlende, pablohoneyhoney
-Stable tag: 1.0.2
+Stable tag: 1.0.3
 Tested up to: 5.6
 Requires at least: 5.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Tags: block, blocks
 
 Stars in motion
 


### PR DESCRIPTION
* Adds tags `block` and `blocks`
* Adds keys `editorScript`, `editorStyle` and `style` to `block.json`
* Bumps version to 1.0.3