### PR TITLE
Revert "Update dependency perfect-freehand to 0.4.91 for Sketch block"

### DIFF
--- a/bundler/bundles/sketch.json
+++ b/bundler/bundles/sketch.json
@@ -1,6 +1,6 @@
 {
 	"blocks": [ "sketch" ],
-	"version": "1.0.8",
+	"version": "1.0.7",
 	"name": "Sketch",
 	"description": "Draw and write freely on a canvas. The block offers color selection, different brush sizes, and with its transparent background can be layered on top of any container block, like groups or covers.",
 	"resource": "a8c-sketch"

--- a/bundler/resources/a8c-sketch/readme.txt
+++ b/bundler/resources/a8c-sketch/readme.txt
@@ -1,6 +1,6 @@
 === Sketch Block ===
 Contributors: automattic, matveb, oskosk, pablohoneyhoney
-Stable tag: 1.0.8
+Stable tag: 1.0.7
 Tested up to: 5.7.2
 Requires at least: 5.7
 License: GPLv2 or later
@@ -29,19 +29,4 @@ You can follow development, file an issue, suggest features, and view the source
 
 1. Sketch Block by Automattic.
 2. Draw and write freely on a canvas.
-
-== Changelog ==
-
-= 1.0.8 - 2nd July 2021 =
-* Address crashing issues when the underlying library detects duplicate strokes
-
-= 1.0.7 - 1st July 2021 =
-* Add example for the block inserter preview
-* Categorize the block under widgets
-
-= 1.0.6 - 1st July 2021 =
-* Improve compatibility with block directory
-
-= 1.0.0 - 1st July 2021 =
-* Initial release
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"@wordpress/blocks": "^8.0.0",
 		"classnames": "^2.3.1",
 		"fast-average-color": "^6.4.0",
-		"perfect-freehand": "0.4.91",
+		"perfect-freehand": "0.4.9",
 		"tinycolor2": "^1.4.2"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11005,10 +11005,10 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
-perfect-freehand@0.4.91:
-  version "0.4.91"
-  resolved "https://registry.yarnpkg.com/perfect-freehand/-/perfect-freehand-0.4.91.tgz#f2992d33b96bb8337cc9a082ab0841e5c59ffd90"
-  integrity sha512-nWCo3+d0mn20+UiambCz+GEfbYkWAUH4tdH/qVlz/lOBR6AcTuXOUJUvX4Qxj+aBqxJCx7T9nlORB6diO3NyMw==
+perfect-freehand@0.4.9:
+  version "0.4.9"
+  resolved "https://registry.yarnpkg.com/perfect-freehand/-/perfect-freehand-0.4.9.tgz#09e9f5a1057da7eda335367d5f1f2c6fbd369e3e"
+  integrity sha512-mNf9Yd2dxWV3kZs2PPNWjLOt8Yh31+PIu6/zst7I8YJOicYBnRofzXl9us5gxqK4ZfHKO5O7PjttHF0tuHfo0g==
 
 performance-now@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Reverts Automattic/block-experiments#223

Updating to perfect-freehand 0.4.91 is not quite straightforward. Some errors show in the console when drawing. Rolling back