### PR TITLE
Update dependency perfect-freehand to 0.4.91 for Sketch block (Second take)

### DIFF
--- a/blocks/sketch/src/edit.js
+++ b/blocks/sketch/src/edit.js
@@ -1,11 +1,7 @@
 /**
- * External dependencies
- */
-import getStroke from 'perfect-freehand';
-/**
  * Internal dependencies
  */
-import { presets, getSvgPathFromStroke } from './lib';
+import { presets, getStroke, getSvgPathFromStroke } from './lib';
 import Controls from './controls';
 /**
  * WordPress dependencies

--- a/blocks/sketch/src/lib.js
+++ b/blocks/sketch/src/lib.js
@@ -23,22 +23,14 @@ export const presets = [
 export function getSvgPathFromStroke( stroke ) {
 	if ( stroke.length === 0 ) return '';
 
-	const d = [];
-
-	let [ p0, p1 ] = stroke;
-
-	d.push( 'M', p0[ 0 ], p0[ 1 ], 'Q' );
-
-	for ( let i = 1; i < stroke.length; i++ ) {
-		d.push(
-			p0[ 0 ],
-			p0[ 1 ],
-			( p0[ 0 ] + p1[ 0 ] ) / 2,
-			( p0[ 1 ] + p1[ 1 ] ) / 2
-		);
-		p0 = p1;
-		p1 = stroke[ i ];
-	}
+	const d = stroke.reduce(
+		( acc, [ x0, y0 ], i, arr ) => {
+			const [ x1, y1 ] = arr[ ( i + 1 ) % arr.length ];
+			acc.push( x0, y0, ( x0 + x1 ) / 2, ( y0 + y1 ) / 2 );
+			return acc;
+		},
+		[ 'M', ...stroke[ 0 ], 'Q' ]
+	);
 
 	d.push( 'Z' );
 

--- a/blocks/sketch/src/lib.js
+++ b/blocks/sketch/src/lib.js
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import _getStroke from 'perfect-freehand';
+
 export const presets = [
 	{
 		size: 3,
@@ -35,4 +40,28 @@ export function getSvgPathFromStroke( stroke ) {
 	d.push( 'Z' );
 
 	return d.join( ' ' );
+}
+
+/**
+ *
+ * Temporary fix for handling most of the crashes in Sfari when the user draws a single dot until we find a better solution
+ * or perfect-freehand gets updated. See https://github.com/steveruizok/perfect-freehand/issues/11#issuecomment-873414323
+ *
+ * @param   {Array}   points
+ * @param   {Object}  options
+ * @return  {Array}   An arrray of points as returned by getStroke
+ */
+export function getStroke( points, options ) {
+	if ( points.length < 3 ) {
+		return _getStroke(
+			[
+				...points,
+				[ points[ 0 ][ 0 ], points[ 0 ][ 1 ] + 1, points[ 0 ][ 2 ] ],
+			],
+			options
+		);
+	}
+	const stroke = _getStroke( points, options );
+
+	return stroke;
 }

--- a/bundler/bundles/sketch.json
+++ b/bundler/bundles/sketch.json
@@ -1,6 +1,6 @@
 {
 	"blocks": [ "sketch" ],
-	"version": "1.0.7",
+	"version": "1.0.8",
 	"name": "Sketch",
 	"description": "Draw and write freely on a canvas. The block offers color selection, different brush sizes, and with its transparent background can be layered on top of any container block, like groups or covers.",
 	"resource": "a8c-sketch"

--- a/bundler/resources/a8c-sketch/readme.txt
+++ b/bundler/resources/a8c-sketch/readme.txt
@@ -1,6 +1,6 @@
 === Sketch Block ===
 Contributors: automattic, matveb, oskosk, pablohoneyhoney
-Stable tag: 1.0.7
+Stable tag: 1.0.8
 Tested up to: 5.7.2
 Requires at least: 5.7
 License: GPLv2 or later
@@ -29,4 +29,19 @@ You can follow development, file an issue, suggest features, and view the source
 
 1. Sketch Block by Automattic.
 2. Draw and write freely on a canvas.
+
+== Changelog ==
+
+= 1.0.8 - 2nd July 2021 =
+* Address crashing issues when the underlying library detects duplicate strokes
+
+= 1.0.7 - 1st July 2021 =
+* Add example for the block inserter preview
+* Categorize the block under widgets
+
+= 1.0.6 - 1st July 2021 =
+* Improve compatibility with block directory
+
+= 1.0.0 - 1st July 2021 =
+* Initial release
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"@wordpress/blocks": "^8.0.0",
 		"classnames": "^2.3.1",
 		"fast-average-color": "^6.4.0",
-		"perfect-freehand": "0.4.9",
+		"perfect-freehand": "0.4.91",
 		"tinycolor2": "^1.4.2"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11005,10 +11005,10 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
-perfect-freehand@0.4.9:
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/perfect-freehand/-/perfect-freehand-0.4.9.tgz#09e9f5a1057da7eda335367d5f1f2c6fbd369e3e"
-  integrity sha512-mNf9Yd2dxWV3kZs2PPNWjLOt8Yh31+PIu6/zst7I8YJOicYBnRofzXl9us5gxqK4ZfHKO5O7PjttHF0tuHfo0g==
+perfect-freehand@0.4.91:
+  version "0.4.91"
+  resolved "https://registry.yarnpkg.com/perfect-freehand/-/perfect-freehand-0.4.91.tgz#f2992d33b96bb8337cc9a082ab0841e5c59ffd90"
+  integrity sha512-nWCo3+d0mn20+UiambCz+GEfbYkWAUH4tdH/qVlz/lOBR6AcTuXOUJUvX4Qxj+aBqxJCx7T9nlORB6diO3NyMw==
 
 performance-now@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
#223 failed. Was reverted by #224 .

#### Changes introduced by this PR

* Potentially address issue with strokes detected as dupicate by the underlying library. Reported in https://wordpress.org/support/topic/this-block-has-encountered-an-error-4/
* Bump version to 1.0.8
* Add changelog section to the readme
* Circumvents error in lib when drawing a Single dot.
