### PR TITLE
Layout Grid: Correctly align image block with right alignment

### DIFF
--- a/blocks/layout-grid/editor.scss
+++ b/blocks/layout-grid/editor.scss
@@ -246,3 +246,13 @@
 		}
 	}
 }
+
+/**
+ * Image alignment for the editor
+ */
+
+.wp-block[data-align=right] {
+    > .wp-block-image {
+        float: right;
+    }
+}


### PR DESCRIPTION
Currently, when adding an image in a Layout Grid block and then setting the image alignment to the right, the change is not reflected in the editor. It works fine on the front end. This PR fixes this by applying `float: right` to the image container (similar to the styles for alignment on the front end.)

![image](https://user-images.githubusercontent.com/1645628/124758311-5a336100-df26-11eb-9c78-444a4e5f8fd2.png)

#### Testing steps:
- Add a layout grid block
- Add an image to the block
- Align the image to the right
- The image should align to the right of its column in the editor

This also addresses a [related issue in themes](https://github.com/Automattic/themes/issues/4158).