### PR TITLE
Sketch Block: Add role img and title

### DIFF
--- a/blocks/sketch/index.php
+++ b/blocks/sketch/index.php
@@ -7,9 +7,11 @@ define( __NAMESPACE__ . '\DEFAULT_HEIGHT', 450);
 function a8c_sketch_render( $attributes ) {
 	$strokes = $attributes['strokes'] ?? [];
 	$align   = $attributes['align'] ?? '';
+	$title   = $attributes['title'] ?? '';
 	$height   = $attributes['height'] ?? DEFAULT_HEIGHT;
 	// The class name that affects alignment is called alignwide, alignfull, etc
 	$align = $align ? " align$align" : '';
+	$title_tag = $title ? sprintf( '<title>%s</title>', esc_html( $title ) ) : '';
 
 	if ( ! isset( $attributes['strokes'] ) || '' === $attributes['strokes'] ) {
 		return '';
@@ -36,6 +38,7 @@ function a8c_sketch_render( $attributes ) {
 	$html =
 		sprintf( '<figure %s %s>', $class, $style ) .
 			'<svg role="img">' .
+				$title_tag .
 				implode( "\n", $paths ) .
 			'</svg>' .
 		'</figure>';

--- a/blocks/sketch/index.php
+++ b/blocks/sketch/index.php
@@ -35,7 +35,7 @@ function a8c_sketch_render( $attributes ) {
 
 	$html =
 		sprintf( '<figure %s %s>', $class, $style ) .
-			'<svg>' .
+			'<svg role="img">' .
 				implode( "\n", $paths ) .
 			'</svg>' .
 		'</figure>';

--- a/blocks/sketch/src/controls.js
+++ b/blocks/sketch/src/controls.js
@@ -102,11 +102,9 @@ const Controls = ( {
 						onChange={ setTitle }
 						help={
 							<>
-								<ExternalLink href="https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title">
-									{ __(
-										'Short-text description of the sketch drawing'
-									) }
-								</ExternalLink>
+								{ __(
+									"Add a short-text description so it's recognized as the accessible name for the sketch."
+								) }
 							</>
 						}
 					/>

--- a/blocks/sketch/src/controls.js
+++ b/blocks/sketch/src/controls.js
@@ -5,10 +5,17 @@ import { ColorControlIcon, BrushSizeControlIcon, BrushSizeIcon } from './icons';
 /**
  * WordPress dependencies
  */
-import { BlockControls, useSetting } from '@wordpress/block-editor';
+import {
+	BlockControls,
+	InspectorControls,
+	useSetting,
+} from '@wordpress/block-editor';
 import {
 	ColorPalette,
+	ExternalLink,
 	Icon,
+	PanelBody,
+	TextareaControl,
 	ToolbarButton,
 	ToolbarDropdownMenu,
 } from '@wordpress/components';
@@ -30,51 +37,82 @@ const brushes = [
 	},
 ];
 
-const Controls = ( { clear, color, setColor, preset, setPreset, isEmpty } ) => {
+const Controls = ( {
+	clear,
+	color,
+	setColor,
+	preset,
+	setPreset,
+	isEmpty,
+	title,
+	setTitle,
+} ) => {
 	const colors = useSetting( 'color.palette' ) || [];
 	return (
-		<BlockControls group="block">
-			<ToolbarDropdownMenu
-				isCollapsed
-				popoverProps={ {
-					className: 'wp-block-a8c-sketch__brush-style-popover',
-					isAlternate: true,
-				} }
-				icon={ <Icon icon={ BrushSizeControlIcon } /> }
-				label={ __( 'Brush', 'sketch' ) }
-				controls={ brushes.map( ( control ) => ( {
-					...control,
-					isActive: control.value === preset,
-					onClick: () => {
-						if ( control.value !== preset ) {
-							setPreset( control.value );
+		<>
+			<BlockControls group="block">
+				<ToolbarDropdownMenu
+					isCollapsed
+					popoverProps={ {
+						className: 'wp-block-a8c-sketch__brush-style-popover',
+						isAlternate: true,
+					} }
+					icon={ <Icon icon={ BrushSizeControlIcon } /> }
+					label={ __( 'Brush', 'sketch' ) }
+					controls={ brushes.map( ( control ) => ( {
+						...control,
+						isActive: control.value === preset,
+						onClick: () => {
+							if ( control.value !== preset ) {
+								setPreset( control.value );
+							}
+						},
+					} ) ) }
+				/>
+				<ToolbarDropdownMenu
+					isCollapsed
+					popoverProps={ { isAlternate: true } }
+					icon={
+						<Icon icon={ <ColorControlIcon color={ color } /> } />
+					}
+					label={ __( 'Color', 'sketch' ) }
+				>
+					{ () => (
+						<ColorPalette
+							clearable={ false }
+							colors={ colors }
+							color={ color }
+							disableCustomColors={ true }
+							onChange={ setColor }
+						/>
+					) }
+				</ToolbarDropdownMenu>
+				<ToolbarButton
+					icon={ trash }
+					onClick={ clear }
+					label={ __( 'Clear canvas', 'sketch' ) }
+					disabled={ isEmpty }
+				/>
+			</BlockControls>
+			<InspectorControls>
+				<PanelBody title={ __( 'Sketch settings' ) }>
+					<TextareaControl
+						label={ __( 'Title' ) }
+						value={ title }
+						onChange={ setTitle }
+						help={
+							<>
+								<ExternalLink href="https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title">
+									{ __(
+										'Short-text description of the sketch drawing'
+									) }
+								</ExternalLink>
+							</>
 						}
-					},
-				} ) ) }
-			/>
-			<ToolbarDropdownMenu
-				isCollapsed
-				popoverProps={ { isAlternate: true } }
-				icon={ <Icon icon={ <ColorControlIcon color={ color } /> } /> }
-				label={ __( 'Color', 'sketch' ) }
-			>
-				{ () => (
-					<ColorPalette
-						clearable={ false }
-						colors={ colors }
-						color={ color }
-						disableCustomColors={ true }
-						onChange={ setColor }
 					/>
-				) }
-			</ToolbarDropdownMenu>
-			<ToolbarButton
-				icon={ trash }
-				onClick={ clear }
-				label={ __( 'Clear canvas', 'sketch' ) }
-				disabled={ isEmpty }
-			/>
-		</BlockControls>
+				</PanelBody>
+			</InspectorControls>
+		</>
 	);
 };
 export default Controls;

--- a/blocks/sketch/src/controls.js
+++ b/blocks/sketch/src/controls.js
@@ -95,7 +95,7 @@ const Controls = ( {
 				/>
 			</BlockControls>
 			<InspectorControls>
-				<PanelBody title={ __( 'Sketch settings' ) }>
+				<PanelBody title={ __( 'Settings' ) }>
 					<TextareaControl
 						label={ __( 'Title' ) }
 						value={ title }

--- a/blocks/sketch/src/controls.js
+++ b/blocks/sketch/src/controls.js
@@ -97,7 +97,7 @@ const Controls = ( {
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
 					<TextareaControl
-						label={ __( 'Title' ) }
+						label={ __( 'Description' ) }
 						value={ title }
 						onChange={ setTitle }
 						help={

--- a/blocks/sketch/src/edit.js
+++ b/blocks/sketch/src/edit.js
@@ -14,7 +14,7 @@ const MIN_HEIGHT = 200;
 const MAX_HEIGHT = 1000;
 
 const Edit = ( { attributes, isSelected, setAttributes } ) => {
-	const { strokes, height } = attributes;
+	const { strokes, height, title } = attributes;
 	const [ currentMark, setCurrentMark ] = useState();
 	const [ preset, setPreset ] = useState( 1 );
 	const [ isResizing, setIsResizing ] = useState( false );
@@ -72,6 +72,8 @@ const Edit = ( { attributes, isSelected, setAttributes } ) => {
 		setIsResizing( true );
 	};
 
+	const setTitle = ( newTitle ) => setAttributes( { title: newTitle } );
+
 	const handleOnResizeStop = ( event, direction, elt, delta ) => {
 		const sketchHeight = Math.min(
 			parseInt( height + delta.height, 10 ),
@@ -123,6 +125,8 @@ const Edit = ( { attributes, isSelected, setAttributes } ) => {
 				preset={ preset }
 				setPreset={ setPreset }
 				isEmpty={ ! strokes.length }
+				title={ title }
+				setTitle={ setTitle }
 			/>
 			<figure { ...blockProps }>
 				<Freehand
@@ -131,6 +135,7 @@ const Edit = ( { attributes, isSelected, setAttributes } ) => {
 					handlePointerUp={ handlePointerUp }
 					strokes={ strokes }
 					currentStroke={ currentStroke }
+					title={ title }
 				/>
 			</figure>
 		</ResizableBox>
@@ -143,6 +148,7 @@ export const Freehand = ( {
 	handlePointerDown,
 	handlePointerMove,
 	handlePointerUp,
+	title,
 } ) => (
 	<svg
 		onPointerDown={ handlePointerDown }
@@ -151,6 +157,7 @@ export const Freehand = ( {
 		style={ { touchAction: 'none' } }
 		role="img"
 	>
+		{ title && <title>{ title }</title> }
 		{ strokes.map( ( stroke, i ) => (
 			<StrokePath key={ i } stroke={ stroke } />
 		) ) }

--- a/blocks/sketch/src/edit.js
+++ b/blocks/sketch/src/edit.js
@@ -149,6 +149,7 @@ export const Freehand = ( {
 		onPointerMove={ handlePointerMove }
 		onPointerUp={ handlePointerUp }
 		style={ { touchAction: 'none' } }
+		role="img"
 	>
 		{ strokes.map( ( stroke, i ) => (
 			<StrokePath key={ i } stroke={ stroke } />

--- a/blocks/sketch/src/index.js
+++ b/blocks/sketch/src/index.js
@@ -20,6 +20,7 @@ const block = {
 	attributes: {
 		strokes: { type: 'array', default: [] },
 		height: { type: 'number', default: 450 },
+		title: { type: 'string', default: '' },
 	},
 	supports: {
 		align: true,


### PR DESCRIPTION
Follows SVG Pattern 5 from https://www.deque.com/blog/creating-accessible-svgs/

* Adds `role=img` and `<title>` to generated SVG
* Adds a panel with a textarea control to the inspector.
  * Links to Mozilla's page describing the title element for an SVG: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title

![image](https://user-images.githubusercontent.com/746152/124967689-152d2e80-dffb-11eb-84a8-016cb1895536.png)


![image](https://user-images.githubusercontent.com/746152/124961690-29216200-dff4-11eb-8418-45e467a048c1.png)
