### PR TITLE
Fix styling for center-aligned events

### DIFF
--- a/blocks/event/editor.scss
+++ b/blocks/event/editor.scss
@@ -10,7 +10,9 @@
 	}
 
 	// Fixes for overriding editor styles
-	.editor-styles-wrapper & {
+	.editor-styles-wrapper &,
+	// Additional specificity needed for center aligned blocks
+	.editor-styles-wrapper .wp-block[data-align="center"] > & {
 		text-align: left;
 
 		p {

--- a/blocks/event/style.scss
+++ b/blocks/event/style.scss
@@ -7,6 +7,11 @@
 	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
 	box-shadow: inset 0 0 0 4px rgba(0,0,0,.1);
 
+	&.aligncenter {
+		display: flex;
+		text-align: left;
+	}
+
 	.event__datebox {
 		float: left;
 		width: 40px;

--- a/bundler/bundles/event.json
+++ b/bundler/bundles/event.json
@@ -1,6 +1,6 @@
 {
 	"blocks": [ "event" ],
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"name": "Event",
 	"description": "Show the time and location of an event",
 	"resource": "a8c-event"

--- a/bundler/resources/a8c-event/block.json
+++ b/bundler/resources/a8c-event/block.json
@@ -2,5 +2,8 @@
 	"name": "a8c/event",
 	"title": "Event",
 	"description": "Let everyone know about the events going on. Whether you're hosting or attending, the event block will feature your event including the time and location.",
-	"category": "widgets"
+	"category": "widgets",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./editor.css",
+	"style": "file:./style.css"
 }

--- a/bundler/resources/a8c-event/readme.txt
+++ b/bundler/resources/a8c-event/readme.txt
@@ -1,7 +1,7 @@
 === Event Block ===
 Contributors: automattic, ajlende, jasmussen
-Stable tag: 1.0.1
-Tested up to: 5.6
+Stable tag: 1.0.2
+Tested up to: 5.8
 Requires at least: 5.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -23,6 +23,10 @@ You can follow development, file an issue, suggest features, and view the source
 2. Customizing the Event Block
 
 == Changelog ==
+
+= 1.0.2 - 22nd July 2021 =
+* Improve compatibility with block directory
+* Fix center aligned styling
 
 = 1.0.1 - 3rd August 2020 =
 * Fix 'Event Description' placeholder internationalization

--- a/bundler/resources/a8c-event/readme.txt
+++ b/bundler/resources/a8c-event/readme.txt
@@ -5,6 +5,7 @@ Tested up to: 5.6
 Requires at least: 5.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Tags: block, event, card
 
 Quickly create simple event cards and invitations
 


### PR DESCRIPTION
Fixes an issue with center-aligned event blocks, and fixes block directory details.

Before:

![Screen Shot 2021-07-20 at 14 12 50](https://user-images.githubusercontent.com/5129775/126374511-50c1d82d-e018-4636-aeff-804028750d86.png)

After:

![Screen Shot 2021-07-20 at 14 13 49](https://user-images.githubusercontent.com/5129775/126374602-990f2307-1406-41ec-ac11-9d36a2b59823.png)