### PR TITLE
Use new frontend scripts method for waves

### DIFF
--- a/blocks/waves/index.php
+++ b/blocks/waves/index.php
@@ -2,13 +2,10 @@
 
 add_action( 'init', function() {
 	register_block_type( 'a8c/waves', [
+		'script' => 'a8c-waves-js',
 		'editor_script' => 'block-experiments',
 		'style' => 'block-experiments',
 		'editor_style' => 'block-experiments-editor',
-		'render_callback' => function( $attribs, $content ) {
-			wp_enqueue_script( 'a8c-waves-js' );
-			return $content;
-		},
 	] );
 	wp_register_script(
 		'a8c-twgl-js',
@@ -26,6 +23,4 @@ add_action( 'init', function() {
 	);
 } );
 
-add_action( 'enqueue_block_editor_assets', function() {
-	wp_enqueue_script( 'a8c-waves-js' );
-} );
+add_filter( 'should_load_separate_core_block_assets', '__return_true' );

--- a/blocks/waves/index.php
+++ b/blocks/waves/index.php
@@ -21,6 +21,7 @@ add_action( 'init', function() {
 		filemtime( plugin_dir_path( __FILE__ ) . 'waves.js' ),
 		true // in footer
 	);
+	wp_set_script_translations( 'block-experiments', 'waves' );
 } );
 
 add_filter( 'should_load_separate_core_block_assets', '__return_true' );

--- a/bundler/bundles/waves.json
+++ b/bundler/bundles/waves.json
@@ -1,6 +1,6 @@
 {
 	"blocks": [ "waves" ],
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"name": "Waves Block",
 	"description": "Blocks can now be sinuous and soothing with the Waves Block.",
 	"resource": "a8c-waves"

--- a/bundler/resources/a8c-waves/block.json
+++ b/bundler/resources/a8c-waves/block.json
@@ -5,5 +5,6 @@
 	"category": "widgets",
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./editor.css",
+	"script": "file:./blocks/waves.js",
 	"style": "file:./style.css"
 }

--- a/bundler/resources/a8c-waves/readme.txt
+++ b/bundler/resources/a8c-waves/readme.txt
@@ -1,7 +1,7 @@
 === Waves Block ===
 Contributors: automattic, ajlende, pablohoneyhoney
-Stable tag: 1.0.2
-Tested up to: 5.6
+Stable tag: 1.0.3
+Tested up to: 5.8
 Requires at least: 5.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -30,6 +30,10 @@ You can follow development, file an issue, suggest features, and view the source
 5. Enjoy the soothing animation.
 
 == Changelog ==
+
+= 1.0.3 - 22nd July 2021 =
+* Use `should_load_separate_core_block_assets` for loading assets
+* Load script translations
 
 = 1.0.2 - 1st July 2021 =
 * Improve compatibility with block directory


### PR DESCRIPTION
Uses [`should_load_separate_core_block_assets`](https://make.wordpress.org/core/2021/07/01/block-styles-loading-enhancements-in-wordpress-5-8/) instead of `render_callback` for loading the frontend script only when the block is loaded.

Also loads script translations with `wp_set_script_translations` since that seems to have been missing when they were added to the other blocks.

Tested with 5.8.