### PR TITLE
RNmobile: Fix the cancel button on Layout Grid Block

### DIFF
--- a/blocks/layout-grid/src/grid/variation-control/style.native.scss
+++ b/blocks/layout-grid/src/grid/variation-control/style.native.scss
@@ -6,6 +6,8 @@
 .variation-control__cancel-button {
     color: $blue-wordpress;
 	font-size: 16px;
+	padding-left: $grid-unit-20;
+	padding-right: $grid-unit-20;
 }
 .variation-control__cancel-button-dark {
     color: $blue-30;


### PR DESCRIPTION
In #34018 we refactored how we apply the padding of the buttons in the navigation header. This Pr add the padding that we missed to add to the layout grid block.

Screenshots:

Before:
<img width="300" alt="Screen Shot 2021-08-23 at 4 29 08 PM" src="https://user-images.githubusercontent.com/115071/130532832-ff0a5391-8e29-4fd3-8e4b-0b25e7187911.png">

After:
<img width="300" alt="Screen Shot 2021-08-23 at 4 34 04 PM" src="https://user-images.githubusercontent.com/115071/130532829-9a04481d-0878-4e3f-8711-d147beea2dac.png">

How has this been tested?

Load the PR on in the mobile app. 
Add the layout grid block. Notice that the cancel button has a padding now. 


related:
https://github.com/WordPress/gutenberg/pull/34249


