### PR TITLE
Fix Layout Grid bottom sheet Android close button

### DIFF
--- a/blocks/layout-grid/src/grid/variation-control/style.native.scss
+++ b/blocks/layout-grid/src/grid/variation-control/style.native.scss
@@ -15,8 +15,9 @@
 
 .variation-control__close-icon {
 	color: $gray;
-	margin-left: $grid-unit-20;
-	padding: $grid-unit-20;
+	margin-left: $grid-unit-10;
+	padding-left: $grid-unit-20;
+	padding-right: $grid-unit-20;
 }
 
 .variation-control__inner-shell {


### PR DESCRIPTION
## Related PRs
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/3876
* https://github.com/WordPress/gutenberg/pull/34332

## Description
Apply required margin and padding to properly align Android close button in the Layout Grid block bottom sheet. Relates to https://github.com/Automattic/block-experiments/pull/238 and https://github.com/WordPress/gutenberg/pull/34332. 

## How has this been tested?
Performed the following on both Android and iOS.

1. Open the block editor. 
2. Add a Layout Grid block. 
3. **Expected:** The X/Cancel button is correct aligned on the left side of the bottom sheet, and not flush with the left side of the screen. 

## Screenshots <!-- if applicable -->

| Before | After |
| - | - |
| ![layout-grid-before-android](https://user-images.githubusercontent.com/438664/130979769-f6fca0cf-0a31-403d-9f18-0ffee4af19a5.jpg) | ![layout-grid-after-android](https://user-images.githubusercontent.com/438664/130981832-2cb16445-a069-4658-b447-b853f5f8e14d.jpg) |
| ![layout-grid-before-ios](https://user-images.githubusercontent.com/438664/130979801-bea555f9-71fa-45db-9b75-74a1a65d6947.PNG) | ![layout-grid-after-ios](https://user-images.githubusercontent.com/438664/130979801-bea555f9-71fa-45db-9b75-74a1a65d6947.PNG) |

## Types of changes
Bug fix