### PR TITLE
Sketch Block - Bump perfect-freehand dependency version to 1.0.16

### DIFF
--- a/blocks/sketch/src/edit.js
+++ b/blocks/sketch/src/edit.js
@@ -1,7 +1,12 @@
 /**
+ * External dependencies
+ */
+import getStroke from 'perfect-freehand';
+
+/**
  * Internal dependencies
  */
-import { presets, getStroke, getSvgPathFromStroke } from './lib';
+import { presets, getSvgPathFromStroke } from './lib';
 import Controls from './controls';
 /**
  * WordPress dependencies

--- a/blocks/sketch/src/lib.js
+++ b/blocks/sketch/src/lib.js
@@ -1,8 +1,3 @@
-/**
- * External dependencies
- */
-import _getStroke from 'perfect-freehand';
-
 export const presets = [
 	{
 		size: 3,
@@ -40,28 +35,4 @@ export function getSvgPathFromStroke( stroke ) {
 	d.push( 'Z' );
 
 	return d.join( ' ' );
-}
-
-/**
- *
- * Temporary fix for handling most of the crashes in Sfari when the user draws a single dot until we find a better solution
- * or perfect-freehand gets updated. See https://github.com/steveruizok/perfect-freehand/issues/11#issuecomment-873414323
- *
- * @param   {Array}   points
- * @param   {Object}  options
- * @return  {Array}   An arrray of points as returned by getStroke
- */
-export function getStroke( points, options ) {
-	if ( points.length < 3 ) {
-		return _getStroke(
-			[
-				...points,
-				[ points[ 0 ][ 0 ], points[ 0 ][ 1 ] + 1, points[ 0 ][ 2 ] ],
-			],
-			options
-		);
-	}
-	const stroke = _getStroke( points, options );
-
-	return stroke;
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"@wordpress/blocks": "^8.0.0",
 		"classnames": "^2.3.1",
 		"fast-average-color": "^6.4.0",
-		"perfect-freehand": "0.4.91",
+		"perfect-freehand": "1.0.16",
 		"tinycolor2": "^1.4.2"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11005,10 +11005,10 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
-perfect-freehand@0.4.91:
-  version "0.4.91"
-  resolved "https://registry.yarnpkg.com/perfect-freehand/-/perfect-freehand-0.4.91.tgz#f2992d33b96bb8337cc9a082ab0841e5c59ffd90"
-  integrity sha512-nWCo3+d0mn20+UiambCz+GEfbYkWAUH4tdH/qVlz/lOBR6AcTuXOUJUvX4Qxj+aBqxJCx7T9nlORB6diO3NyMw==
+perfect-freehand@1.0.16:
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/perfect-freehand/-/perfect-freehand-1.0.16.tgz#38575ef946ff513b9c94057c763cac003b504020"
+  integrity sha512-D4+avUeR8CHSl2vaPbPYX/dNpSMRYO3VOFp7qSSc+LRkSgzQbLATVnXosy7VxtsSHEh1C5t8K8sfmo0zCVnfWQ==
 
 performance-now@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
* Updates package dependency
* Removes circumvention for [this-block-has-encountered-an-error-4](https://wordpress.org/support/topic/this-block-has-encountered-an-error-4/)  introduced in https://github.com/Automattic/block-experiments/pull/225