### PR TITLE
Full Site Editing: Prefer site editor viewport settings when changing the preview device type

### DIFF
--- a/blocks/layout-grid/src/grid/higher-order.js
+++ b/blocks/layout-grid/src/grid/higher-order.js
@@ -122,9 +122,9 @@ export function withSetPreviewDeviceType() {
 	return withDispatch( ( dispatch ) => {
 		return {
 			setPreviewDeviceType( type ) {
-				const { __experimentalSetPreviewDeviceType } = dispatch(
-					'core/edit-post'
-				);
+				const { __experimentalSetPreviewDeviceType } =
+					dispatch( 'core/edit-site' ) ||
+					dispatch( 'core/edit-post' );
 				__experimentalSetPreviewDeviceType( type );
 			},
 		};
@@ -158,9 +158,8 @@ export function withColumnAttributes() {
 
 export function withPreviewDeviceType() {
 	return withSelect( ( select ) => {
-		const { __experimentalGetPreviewDeviceType = null } = select(
-			'core/edit-post'
-		);
+		const { __experimentalGetPreviewDeviceType = null } =
+			select( 'core/edit-site' ) || select( 'core/edit-post' );
 
 		return {
 			previewDeviceType: __experimentalGetPreviewDeviceType(),


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/57158.

When we are trying to set a different preview device inside FSE, the "Layout Grid" block ignores the FSE device type and uses the internal (`core/edit-post`) responsive breakpoints setting instead of `core/edit-site`, which should take precedence inside FSE.

We must take the `core/edit-site` registry into consideration, which is only registered if we are inside FSE, to properly layout the grid when changing the device type.

Ideally, we would have a centralized, agnostic way of referencing/setting the preview device type, instead of needing to reference two different registries. I'm happy to create an issue as a follow-up, as it possibly demands extensive refactor.

## Behavior on `master`

https://user-images.githubusercontent.com/10015451/137959268-8e3b4189-3278-427a-9441-0cb265cc26b3.mp4

## Expected/this branch's behavior

https://user-images.githubusercontent.com/10015451/137959354-99eb95b3-8864-4538-a326-04549fd50314.mp4

Check that it works both on post and site editor.