### PR TITLE
Bump version of jetpack-layout-grid to 1.7.2 and update CHANGELOG

### DIFF
--- a/bundler/bundles/layout-grid.json
+++ b/bundler/bundles/layout-grid.json
@@ -2,7 +2,7 @@
 	"blocks": [
 		"layout-grid"
 	],
-	"version": "1.7.1",
+	"version": "1.7.2",
 	"name": "Layout Grid",
 	"description": "Let any blocks align to a global grid",
 	"resource": "jetpack-layout-grid",

--- a/bundler/resources/jetpack-layout-grid/readme.txt
+++ b/bundler/resources/jetpack-layout-grid/readme.txt
@@ -24,6 +24,9 @@ You can follow development, file an issue, suggest features, and view the source
 
 == Changelog ==
 
+= 1.7.2 - 19th November 2021 =
+* Prefer site editor viewport settings when changing the preview device type
+
 = 1.7.1 - 11th November 2021 =
 * Show block in excerpts
 


### PR DESCRIPTION
After merging #247, we need to update the version and the changelog for the specific block we updated. This PR does exactly that.