### PR TITLE
Layout Grid: Fix vertical alignment and background colors.

### DIFF
--- a/blocks/layout-grid/editor.scss
+++ b/blocks/layout-grid/editor.scss
@@ -35,6 +35,7 @@
  */
 
 // Make sure each column is full height in the editor, as it is on the frontend.
+[data-type="jetpack/layout-grid-column"],
 [data-type="jetpack/layout-grid-column"] > .block-editor-block-list__block-edit,
 [data-type="jetpack/layout-grid-column"] > .block-editor-block-list__block-edit > [data-block],
 .wp-block-jetpack-layout-grid-column {

--- a/blocks/layout-grid/style.scss
+++ b/blocks/layout-grid/style.scss
@@ -186,16 +186,22 @@
  * Individual column alignment
  */
 .wp-block-jetpack-layout-grid-column {
+	display: flex;
+	height: 100%;
+
 	&.is-vertically-aligned-top {
 		align-self: flex-start;
+		align-items: flex-start;
 	}
 
 	&.is-vertically-aligned-center {
 		align-self: center;
+		align-items: center;
 	}
 
 	&.is-vertically-aligned-bottom {
 		align-self: flex-end;
+		align-items: flex-end;
 	}
 }
 


### PR DESCRIPTION
Fixes #250.

The primary issue this solves is to ensure that the vertical alignment of content inside a column works in the _site editor_, where it's currently broken:

<img width="1227" alt="site editor is not" src="https://user-images.githubusercontent.com/1204802/146166040-3d68116c-200f-4097-89dd-cddcd1857178.png">

 In the post editor, it's fine:
<img width="1223" alt="post editor is fine" src="https://user-images.githubusercontent.com/1204802/146166017-46dd2988-6769-4be1-b066-154c099ed576.png">

In exploring the cause and the fix, it appears that both markup and structure has changed and simplified a bit in the core offering, meaning some rules targetting specific markup stopped working. I also recall some upstream vertical centering rules changing — those rules may or may not affect this plugin. @andrewserong if you have time to look, I'd appreciate it. 

I also realized based on the commentary, that another feature had likely stopped working:

> // Make sure each column is full height in the editor, as it is on the frontend.

Specifically, I recall a use case being to apply background colors on a per-column basis. That appears to have broken, both in the post and site editors:

<img width="945" alt="Screenshot 2021-12-15 at 11 08 00" src="https://user-images.githubusercontent.com/1204802/146166811-83bed4c8-3371-45a7-869e-9ae934f5d705.png">

This PR fixes it for both editors:
<img width="961" alt="Screenshot 2021-12-15 at 10 59 46" src="https://user-images.githubusercontent.com/1204802/146166870-4a7da3e2-02a2-4079-9691-6f28a9f93e7c.png">

<img width="943" alt="Screenshot 2021-12-15 at 11 00 09" src="https://user-images.githubusercontent.com/1204802/146166878-45295a72-f884-4e34-9351-431cfa1b2aaf.png">