### PR TITLE
Layout Grid: Fix vertical alignment, round 2

### DIFF
--- a/blocks/layout-grid/editor.scss
+++ b/blocks/layout-grid/editor.scss
@@ -34,16 +34,18 @@
  * Visual Glitches
  */
 
-// Make sure each column is full height in the editor, as it is on the frontend.
-[data-type="jetpack/layout-grid-column"] > .block-editor-block-list__block-edit,
-[data-type="jetpack/layout-grid-column"] > .block-editor-block-list__block-edit > [data-block],
+// This prevents collapsing margins, which makes for a more stable experience.
+// It is definitely needed for background colors to work.
 .wp-block-jetpack-layout-grid-column {
-	height: 100%;
-
-	// This prevents collapsing margins, which makes for a more stable experience.
-	// It is definitely needed for background colors to work.
 	border-top: 0.05px solid transparent;
 	border-bottom: 0.05px solid transparent;
+}
+
+// There are extra containers in the editing canvas. They need to be set to grid
+// same as the corresponding containers on the frontend, to match.
+[data-type="jetpack/layout-grid-column"] {
+	display: grid;
+	height: 100%;
 }
 
 // When grid is full-wide, pad the inner blocks so the side UI is available, including resize handles.

--- a/blocks/layout-grid/style.scss
+++ b/blocks/layout-grid/style.scss
@@ -168,7 +168,8 @@
 /**
  * Parent column alignment
  */
-.wp-block-jetpack-layout-grid {
+
+ .wp-block-jetpack-layout-grid {
 	&.are-vertically-aligned-top {
 		align-items: flex-start;
 	}
@@ -185,9 +186,12 @@
 /**
  * Individual column alignment
  */
-.wp-block-jetpack-layout-grid-column {
+
+ .wp-block-jetpack-layout-grid-column {
+	// Allow top-aligned columns to span the full height.
 	&.is-vertically-aligned-top {
 		align-self: flex-start;
+		height: 100%;
 	}
 
 	&.is-vertically-aligned-center {

--- a/blocks/layout-grid/style.scss
+++ b/blocks/layout-grid/style.scss
@@ -165,11 +165,12 @@
 	}
 }
 
+
 /**
  * Parent column alignment
  */
 
- .wp-block-jetpack-layout-grid {
+.wp-block-jetpack-layout-grid {
 	&.are-vertically-aligned-top {
 		align-items: flex-start;
 	}
@@ -183,11 +184,12 @@
 	}
 }
 
+
 /**
  * Individual column alignment
  */
 
- .wp-block-jetpack-layout-grid-column {
+.wp-block-jetpack-layout-grid-column {
 	// Allow top-aligned columns to span the full height.
 	&.is-vertically-aligned-top {
 		align-self: flex-start;


### PR DESCRIPTION
Alternative to #252. Fixes #250. A few things going on:

- You can colorize column background colors.
- You can vertically align the contents of columns.
- Margins collapse.

Together these present a bit of a challenge; if we wanted a full height colored background for a column with text bottom aligned, then it would have to be a flex container, as #252 does. But that breaks margin collapsing.

It seems we've supported full height columns, but never for an alignment other than _top_ (please correct me if I'm wrong). And so the smaller fix in this PR adjusts the rules for that to match, and cleans things up a bit. 

Site editor before (vertical alignments didn't work):
<img width="886" alt="Screenshot 2021-12-16 at 12 12 20" src="https://user-images.githubusercontent.com/1204802/146361449-1756d895-c525-4f82-a9d4-7b33519d62da.png">

Site editor after (vertical alignments work, and columns are full height when top aligned):

<img width="894" alt="Screenshot 2021-12-16 at 12 07 46" src="https://user-images.githubusercontent.com/1204802/146361502-21a09c9b-c468-4c59-b458-70ecb53fa45b.png">

Post editor and frontend also work the same:
<img width="1063" alt="Screenshot 2021-12-16 at 12 07 52" src="https://user-images.githubusercontent.com/1204802/146361551-8d26f6e7-40e5-44bd-83ba-d025e2642fe0.png">
<img width="1095" alt="Screenshot 2021-12-16 at 12 07 58" src="https://user-images.githubusercontent.com/1204802/146361558-ffa9e8cc-68d8-4c61-8934-007f84959ac9.png">

In fixing this, I've noticed a few regressions with the appender and the inspector which I'll follow up on separately.
