### PR TITLE
Fix a few small glitches

### DIFF
--- a/blocks/layout-grid/editor.scss
+++ b/blocks/layout-grid/editor.scss
@@ -9,11 +9,12 @@
 
 // Unset many of the paddings and margins the block editor sets.
 // This is to make sure resizing the column containers works as expected.
+// These rules exist to support classic themes, and are unnecessary in block themes.
 
 // 1. Reset margins on block itself, so it doesn't inherit the baseline margin.
 [data-type="jetpack/layout-grid"] {
-    margin-top: 0;
-    margin-bottom: 0;
+	margin-top: 0;
+	margin-bottom: 0;
 }
 
 // 2. Reset margins on immediate innerblocks container.
@@ -48,6 +49,7 @@
 	height: 100%;
 }
 
+
 // When grid is full-wide, pad the inner blocks so the side UI is available, including resize handles.
 // To make sure this is smooth, we add some animation.
 // For now this whole bit exists so the side UI, and resize handles, are available even on full-wide blocks.
@@ -63,21 +65,6 @@
 	.is-block-content {
 		width: 100%;
 	}
-}
-
-// Make the columns appender margin match the default block margin.
-// @todo: this margin will possibly be retired in the future. Revisit then.
-.wp-block-jetpack-layout-grid-column > .block-editor-inner-blocks > .block-editor-block-list__layout > .block-list-appender {
-	margin: 28px 0;
-}
-
-// Override and adjust rule inherited from the core project.
-.wp-block:not(.is-selected):not(.has-child-selected) .block-editor-default-block-appender {
-	display: inherit;
-}
-
-[data-type="jetpack/layout-grid"]:not(.is-selected):not(.has-child-selected) .block-editor-default-block-appender {
-	display: none;
 }
 
 

--- a/blocks/layout-grid/editor.scss
+++ b/blocks/layout-grid/editor.scss
@@ -85,14 +85,31 @@
  * Inspector Controls
  */
 
-.jetpack-layout-grid-columns .block-editor-block-styles__item-preview {
-	position: relative;
+.jetpack-layout-grid-columns {
+	display: flex;
+	justify-content: space-between;
+	font-size: 12px;
+	margin-bottom: 12px;
 
-	svg {
-		position: absolute;
-		top: 50%;
-		left: 50%;
-		transform: translate(-50%, -50%);
+	.block-editor-block-styles__item-preview {
+		display: flex;
+		justify-content: center;
+
+		svg {
+			fill: currentColor;
+		}
+	}
+
+	.block-editor-block-styles__item {
+		border-radius: 2px;
+		flex: 1;
+		cursor: pointer;
+		text-align: center;
+
+		&.is-active {
+			background-color: #1e1e1e;
+			color: #fff;
+		}
 	}
 }
 
@@ -114,6 +131,13 @@
 		margin-right: 16px;
 	}
 }
+
+.jetpack-layout-grid-help {
+	font-size: 12px;
+	font-style: normal;
+	color: #757575;
+}
+
 
 
 /**

--- a/blocks/layout-grid/src/constants.js
+++ b/blocks/layout-grid/src/constants.js
@@ -26,19 +26,19 @@ export const getGutterValues = () =>
 
 export const getColumns = () => [
 	{
-		label: __( '1 column', 'layout-grid' ),
+		label: __( '1 cols', 'layout-grid' ),
 		value: 1,
 	},
 	{
-		label: __( '2 columns', 'layout-grid' ),
+		label: __( '2 cols', 'layout-grid' ),
 		value: 2,
 	},
 	{
-		label: __( '3 columns', 'layout-grid' ),
+		label: __( '3 cols', 'layout-grid' ),
 		value: 3,
 	},
 	{
-		label: __( '4 columns', 'layout-grid' ),
+		label: __( '4 cols', 'layout-grid' ),
 		value: 4,
 	},
 ];

--- a/blocks/layout-grid/src/grid/edit.js
+++ b/blocks/layout-grid/src/grid/edit.js
@@ -417,13 +417,11 @@ class Edit extends Component {
 								) ) }
 							</div>
 
-							<p>
-								<em>
-									{ __(
-										'Changing the number of columns will reset your layout and could remove content.',
-										'layout-grid'
-									) }
-								</em>
+							<p className='jetpack-layout-grid-help'>
+								{ __(
+									'Changing the number of columns will reset your layout and could remove content.',
+									'layout-grid'
+								) }
 							</p>
 						</PanelBody>
 
@@ -433,13 +431,11 @@ class Edit extends Component {
 								'layout-grid'
 							) }
 						>
-							<p>
-								<em>
-									{ __(
-										"Note that previewing your post will show your browser's breakpoint, not the currently selected one.",
-										'layout-grid'
-									) }
-								</em>
+							<p className='jetpack-layout-grid-help'>
+								{ __(
+									"Previewing your post will show your browser's breakpoint, not the currently selected one.",
+									'layout-grid'
+								) }
 							</p>
 							<ButtonGroup>
 								{ getLayouts().map( ( layout ) => (


### PR DESCRIPTION
As the block editor has evolved, a few things gathered a little dust here. The inspector control for selecting columns is a bit broken:
<img width="304" alt="before" src="https://user-images.githubusercontent.com/1204802/146516514-225621f3-7570-465c-99fb-f31a2c86bb0b.png">

This PR polishes that:

<img width="307" alt="after" src="https://user-images.githubusercontent.com/1204802/146516535-42fd882d-ae70-43db-bc86-476a5b40c260.png">

The fixed position appender sat in a bit of a random place:

<img width="949" alt="before appender" src="https://user-images.githubusercontent.com/1204802/146516559-ff49bbeb-b293-460f-b13d-3fe26c5303e0.png">

Now it's better:
<img width="961" alt="after appender" src="https://user-images.githubusercontent.com/1204802/146516570-53e0886e-c79e-4ed7-a26a-848277353eab.png">

Note that the fixes here are not superb or perfect. If we have time to invest, there are a lot of things we can improve by adopting the core components for the inspector, for example and refactoring to remove some of the CSS that was needed for older themes. But for now, this is a bit of a bandaid, which at the same time is mostly careful about not making too big changes. What do you think?

