### PR TITLE
Change layout grid to not be fullwide by default.

### DIFF
--- a/blocks/layout-grid/src/index.js
+++ b/blocks/layout-grid/src/index.js
@@ -89,10 +89,6 @@ export function registerBlock() {
 			],
 		},
 		attributes: {
-			align: {
-				type: 'string',
-				default: 'full',
-			},
 			gutterSize: {
 				type: 'string',
 				default: 'large',


### PR DESCRIPTION
Per a conversation in https://github.com/Automattic/block-experiments/issues/249#issuecomment-1008612929, it isn't always obvious why a layout grid block does not appear to be full-wide, if it's inside a group block that's not full-wide. 

I suspect that there are upstream improvements that can be made, but in the mean time, we can make full-wide be an opt-in. What do you think?

<img width="777" alt="Screenshot 2022-01-11 at 12 18 35" src="https://user-images.githubusercontent.com/1204802/148933985-390f2de4-de82-4493-8379-7c483b82a695.png">

