### PR TITLE
Fix issue with invisible style on column picker.

### DIFF
--- a/blocks/layout-grid/editor.scss
+++ b/blocks/layout-grid/editor.scss
@@ -79,8 +79,10 @@
 	margin-bottom: 12px;
 
 	.block-editor-block-styles__item-preview {
+		background: none;
 		display: flex;
 		justify-content: center;
+		min-height: auto;
 
 		svg {
 			fill: currentColor;


### PR DESCRIPTION
The style for item preview buttons is being simplified in the upstream block editor, but Layout Grid has to work across both older and newer versions. That causes some issues with styles that exist in 5.8.3, but are removed in the plugin and later, such as this white background:
<img width="366" alt="Screenshot 2022-01-25 at 11 49 15" src="https://user-images.githubusercontent.com/1204802/150963747-37481b11-f736-43ca-98d8-987409843c60.png">

This PR explicitly unsets it, so the new style works again:
<img width="309" alt="Screenshot 2022-01-25 at 11 51 16" src="https://user-images.githubusercontent.com/1204802/150963809-8624f244-d771-4a47-a24a-e77c9b7d5b29.png">


