### PR TITLE
Layout Grid - Fix preview buttons in post editor

### DIFF
--- a/blocks/layout-grid/src/grid/higher-order.js
+++ b/blocks/layout-grid/src/grid/higher-order.js
@@ -127,7 +127,7 @@ export function withSetPreviewDeviceType() {
 				);
 
 				if ( isSiteEditor ) {
-					dispatch(
+					return dispatch(
 						'core/edit-site'
 					)?.__experimentalSetPreviewDeviceType( type );
 				}

--- a/blocks/layout-grid/src/grid/higher-order.js
+++ b/blocks/layout-grid/src/grid/higher-order.js
@@ -122,17 +122,19 @@ export function withSetPreviewDeviceType() {
 	return withDispatch( ( dispatch ) => {
 		return {
 			setPreviewDeviceType( type ) {
-				const {
-					__experimentalSetPreviewDeviceType: setSiteEditorDeviceType,
-				} = dispatch( 'core/edit-site' );
+				const isSiteEditor = document.querySelector(
+					'#edit-site-editor'
+				);
 
-				if ( setSiteEditorDeviceType ) {
-					setSiteEditorDeviceType( type );
-				} else {
+				if ( isSiteEditor ) {
 					dispatch(
-						'core/edit-post'
-					).__experimentalSetPreviewDeviceType( type );
+						'core/edit-site'
+					)?.__experimentalSetPreviewDeviceType( type );
 				}
+
+				dispatch(
+					'core/edit-post'
+				)?.__experimentalSetPreviewDeviceType( type );
 			},
 		};
 	} );
@@ -165,20 +167,21 @@ export function withColumnAttributes() {
 
 export function withPreviewDeviceType() {
 	return withSelect( ( select ) => {
-		const {
-			__experimentalGetPreviewDeviceType: siteEditorPreviewType = null,
-		} = select( 'core/edit-site' );
+		const isSiteEditor = document.querySelector( '#edit-site-editor' );
 
-		if ( siteEditorPreviewType ) {
+		const siteEditorPreviewDeviceType = select( 'core/edit-site' )
+			?.__experimentalGetPreviewDeviceType;
+		const postEditorPreviewDeviceType = select( 'core/edit-post' )
+			?.__experimentalGetPreviewDeviceType;
+
+		if ( isSiteEditor ) {
 			return {
-				previewDeviceType: siteEditorPreviewType(),
+				previewDeviceType: siteEditorPreviewDeviceType(),
 			};
 		}
 
 		return {
-			previewDeviceType: select(
-				'core/edit-post'
-			)?.__experimentalGetPreviewDeviceType(),
+			previewDeviceType: postEditorPreviewDeviceType(),
 		};
 	} );
 }

--- a/blocks/layout-grid/src/grid/higher-order.js
+++ b/blocks/layout-grid/src/grid/higher-order.js
@@ -122,10 +122,17 @@ export function withSetPreviewDeviceType() {
 	return withDispatch( ( dispatch ) => {
 		return {
 			setPreviewDeviceType( type ) {
-				const { __experimentalSetPreviewDeviceType } =
-					dispatch( 'core/edit-site' ) ||
-					dispatch( 'core/edit-post' );
-				__experimentalSetPreviewDeviceType( type );
+				const {
+					__experimentalSetPreviewDeviceType: setSiteEditorDeviceType,
+				} = dispatch( 'core/edit-site' );
+
+				if ( setSiteEditorDeviceType ) {
+					setSiteEditorDeviceType( type );
+				} else {
+					dispatch(
+						'core/edit-post'
+					).__experimentalSetPreviewDeviceType( type );
+				}
 			},
 		};
 	} );
@@ -158,11 +165,20 @@ export function withColumnAttributes() {
 
 export function withPreviewDeviceType() {
 	return withSelect( ( select ) => {
-		const { __experimentalGetPreviewDeviceType = null } =
-			select( 'core/edit-site' ) || select( 'core/edit-post' );
+		const {
+			__experimentalGetPreviewDeviceType: siteEditorPreviewType = null,
+		} = select( 'core/edit-site' );
+
+		if ( siteEditorPreviewType ) {
+			return {
+				previewDeviceType: siteEditorPreviewType(),
+			};
+		}
 
 		return {
-			previewDeviceType: __experimentalGetPreviewDeviceType(),
+			previewDeviceType: select(
+				'core/edit-post'
+			)?.__experimentalGetPreviewDeviceType(),
 		};
 	} );
 }

--- a/blocks/layout-grid/src/grid/higher-order.js
+++ b/blocks/layout-grid/src/grid/higher-order.js
@@ -169,19 +169,18 @@ export function withPreviewDeviceType() {
 	return withSelect( ( select ) => {
 		const isSiteEditor = document.querySelector( '#edit-site-editor' );
 
-		const siteEditorPreviewDeviceType = select( 'core/edit-site' )
-			?.__experimentalGetPreviewDeviceType;
-		const postEditorPreviewDeviceType = select( 'core/edit-post' )
-			?.__experimentalGetPreviewDeviceType;
-
 		if ( isSiteEditor ) {
 			return {
-				previewDeviceType: siteEditorPreviewDeviceType(),
+				previewDeviceType: select(
+					'core/edit-site'
+				)?.__experimentalGetPreviewDeviceType(),
 			};
 		}
 
 		return {
-			previewDeviceType: postEditorPreviewDeviceType(),
+			previewDeviceType: select(
+				'core/edit-post'
+			)?.__experimentalGetPreviewDeviceType(),
 		};
 	} );
 }

--- a/blocks/layout-grid/src/grid/higher-order.js
+++ b/blocks/layout-grid/src/grid/higher-order.js
@@ -50,6 +50,11 @@ function getColumnBlocks( currentBlocks, previous, columns ) {
 		.reverse();
 }
 
+function isSiteEditor() {
+	const siteEditorWrapper = document.querySelector( '#edit-site-editor' );
+	return !! siteEditorWrapper;
+}
+
 export function withUpdateAlignment() {
 	return withDispatch( ( dispatch, ownProps, registry ) => {
 		return {
@@ -122,11 +127,7 @@ export function withSetPreviewDeviceType() {
 	return withDispatch( ( dispatch ) => {
 		return {
 			setPreviewDeviceType( type ) {
-				const isSiteEditor = document.querySelector(
-					'#edit-site-editor'
-				);
-
-				if ( isSiteEditor ) {
+				if ( isSiteEditor() ) {
 					return dispatch(
 						'core/edit-site'
 					)?.__experimentalSetPreviewDeviceType( type );
@@ -167,9 +168,7 @@ export function withColumnAttributes() {
 
 export function withPreviewDeviceType() {
 	return withSelect( ( select ) => {
-		const isSiteEditor = document.querySelector( '#edit-site-editor' );
-
-		if ( isSiteEditor ) {
+		if ( isSiteEditor() ) {
 			return {
 				previewDeviceType: select(
 					'core/edit-site'


### PR DESCRIPTION
Resolves  https://github.com/Automattic/wp-calypso/issues/62485

We can not rely on absence of the `core/edit-site` store for determining which device type functions should be called. Previously this did work, as the `core/edit-site` store was not available in the post editor while the `core/edit-post` store was available in both editors. In some cases, the `core/edit-site` store is present in the post editor context, causing errors with the device preview feature of this block when used in the post editor (as it tries to fire site editor functions instead of post editor ones). 

Here, we simply check for the edit `#edit-site-editor` container selector to determine which store to use for syncing the preview device type.

# Testing instructions
* Run this PR and build the block-experiments plugin, sync and enable it on a WordPress site.
* Add a Layout Grid block and initialize it with some column selection.
* In the block inspector sidebar, try the 3 device type buttons for Desktop, Tablet, and Mobile.
* Verify these set the preview device as expected in the editor canvas in both the Site Editor as well as the page/post Editor.