### PR TITLE
sketch: switch components position between figure and ResizableBox

### DIFF
--- a/blocks/sketch/src/edit.js
+++ b/blocks/sketch/src/edit.js
@@ -99,31 +99,7 @@ const Edit = ( { attributes, isSelected, setAttributes } ) => {
 		color,
 	};
 	return (
-		<ResizableBox
-			size={ {
-				height,
-			} }
-			minHeight={ MIN_HEIGHT }
-			enable={ {
-				top: false,
-				right: false,
-				bottom: true,
-				left: false,
-				topRight: false,
-				bottomRight: false,
-				bottomLeft: false,
-				topLeft: false,
-			} }
-			onResizeStart={ handleOnResizeStart }
-			onResizeStop={ handleOnResizeStop }
-			showHandle={ isSelected }
-			__experimentalShowTooltip={ true }
-			__experimentalTooltipProps={ {
-				axis: 'y',
-				position: 'bottom',
-				isVisible: isResizing,
-			} }
-		>
+		<>
 			<Controls
 				clear={ clear }
 				color={ color }
@@ -135,6 +111,31 @@ const Edit = ( { attributes, isSelected, setAttributes } ) => {
 				setTitle={ setTitle }
 			/>
 			<figure { ...blockProps }>
+			<ResizableBox
+				size={ {
+					height,
+				} }
+				minHeight={ MIN_HEIGHT }
+				enable={ {
+					top: false,
+					right: false,
+					bottom: true,
+					left: false,
+					topRight: false,
+					bottomRight: false,
+					bottomLeft: false,
+					topLeft: false,
+				} }
+				onResizeStart={ handleOnResizeStart }
+				onResizeStop={ handleOnResizeStop }
+				showHandle={ isSelected }
+				__experimentalShowTooltip={ true }
+				__experimentalTooltipProps={ {
+					axis: 'y',
+					position: 'bottom',
+					isVisible: isResizing,
+				} }
+			>
 				<Freehand
 					handlePointerDown={ handlePointerDown }
 					handlePointerMove={ handlePointerMove }
@@ -143,8 +144,9 @@ const Edit = ( { attributes, isSelected, setAttributes } ) => {
 					currentStroke={ currentStroke }
 					title={ title }
 				/>
+				</ResizableBox>
 			</figure>
-		</ResizableBox>
+		</>
 	);
 };
 


### PR DESCRIPTION
AFAIK, `<ResizableBox />` should not be the main wrapper of the component in the Block context. This PR switches the position between it and the `<figure />` element which becomes the main wrapper.

Visual issues: misalignment of the sketch block

before | after
------|------
<img width="693" alt="image" src="https://user-images.githubusercontent.com/77539/173235166-39a372f2-001d-4298-8cd3-2d60d892ac0a.png"> | <img width="814" alt="image" src="https://user-images.githubusercontent.com/77539/173235191-e90b4034-449a-4b5a-b0ad-1114ef79909d.png">

Also, it produces some flickers when selecting the block.
