### PR TITLE
update for layout-grid 1.8.2

### DIFF
--- a/bundler/bundles/layout-grid.json
+++ b/bundler/bundles/layout-grid.json
@@ -2,7 +2,7 @@
 	"blocks": [
 		"layout-grid"
 	],
-	"version": "1.8.1",
+	"version": "1.8.2",
 	"name": "Layout Grid",
 	"description": "Let any blocks align to a global grid",
 	"resource": "jetpack-layout-grid",

--- a/bundler/resources/jetpack-layout-grid/readme.txt
+++ b/bundler/resources/jetpack-layout-grid/readme.txt
@@ -24,6 +24,9 @@ You can follow development, file an issue, suggest features, and view the source
 
 == Changelog ==
 
+= 1.8.2 - 16th June 2022 =
+* Update device preview handling to be more consistent
+
 = 1.8.1 - 18th March 2022 =
 * Change layout grid to not be fullwide by default
 


### PR DESCRIPTION
Updating version to ship fix for device previewing in post editor. (https://github.com/Automattic/block-experiments/pull/276)