### PR TITLE
Sketch: Update save to store svg in post content instead of rendering dynamically

### DIFF
--- a/blocks/sketch/index.php
+++ b/blocks/sketch/index.php
@@ -92,4 +92,3 @@ function get_svg_path_from_stroke( $stroke ) {
 }
 
 add_action( 'init', __NAMESPACE__ . '\set_render_callback' );
-

--- a/blocks/sketch/src/save.js
+++ b/blocks/sketch/src/save.js
@@ -4,10 +4,66 @@
 import { __ } from '@wordpress/i18n';
 import { useBlockProps } from '@wordpress/block-editor';
 
-const Save = () => {
+const Save = ( { attributes } ) => {
 	const blockProps = useBlockProps.save();
 
-	return <figure { ...blockProps }></figure>;
+	const strokes = attributes.strokes ?? [];
+	const height  = attributes.height ?? 450;
+
+	const align = attributes.align ? ` align${ attributes.align }` : '';
+	const title = attributes.title ? `<title>${ attributes.title }</title>` : '';
+
+	if ( ! attributes.strokes || '' === attributes.strokes ) {
+		return <figure { ...blockProps }></figure>;
+	}
+
+	const paths = strokes.map( ( stroke ) => {
+		if ( ! stroke.stroke || '' === stroke.stroke || ! stroke.color || '' === stroke.color ) {
+			return '';
+		}
+
+		return <path fill={ stroke.color } d={ getSvgPathFromStroke( stroke.stroke ) } />;
+	} );
+
+	return (
+		<figure { ...blockProps }>
+			<svg role="img" >
+				{ title }
+				{ paths }
+			</svg>
+		</figure>
+	);
+};
+
+const getSvgPathFromStroke = function( stroke ) {
+	if ( stroke.length === 0 ) {
+		return '';
+	}
+
+	const d = [];
+
+	let p0 = stroke[ 0 ];
+	let p1 = stroke[ 1 ];
+
+	d.push( 'M', p0[ 0 ], p0[ 1 ], 'Q' );
+
+	const nMarks = stroke.length;
+
+	for ( let i = 1; i < nMarks; i++ ) {
+
+		d.push(
+			p0[ 0 ],
+			p0[ 1 ],
+			( p0[ 0 ] + p1[ 0 ] ) / 2,
+			( p0[ 1 ] + p1[ 1 ] ) / 2
+		);
+		p0 = p1;
+		p1 = stroke[ i ];
+	}
+
+	d.push( 'Z' );
+
+	return d.join( ' ' );
 };
 
 export default Save;


### PR DESCRIPTION
This is a first pass at updating the Sketch block to store the SVG markup in the post content as opposed to rendering the SVG dynamically on post generation. The reasoning for this is that we can provide a better fallback for when the Sketch block does not exist.

Why does this matter?

We are considering how to deploy the Sketch block to WordPress.com. One option here is to simply ship the plugin to WordPress.com. The downside to this is that we also have to consider Atomic sites. There are options for this. The simplest one seems to be to install the Sketch plugin when they'd like to update their block, but otherwise to default to rendering the block.