### PR TITLE
Set SCRIPT_DEBUG true on development environment

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,4 +1,7 @@
 {
 	"core": "WordPress/WordPress#master",
-	"plugins": [ "." ]
+	"plugins": [ "." ],
+	"config": {
+		"SCRIPT_DEBUG": true
+	}
 }


### PR DESCRIPTION
Adds `config.SCRIPT_DEBUG: true` to `.wp-env.json`

