### PR TITLE
Sketch block: Set minimum height to 1px

### DIFF
--- a/blocks/sketch/src/edit.js
+++ b/blocks/sketch/src/edit.js
@@ -16,7 +16,7 @@ import { useState, useRef } from '@wordpress/element';
 import { useBlockProps } from '@wordpress/block-editor';
 import { ResizableBox } from '@wordpress/components';
 
-const MIN_HEIGHT = 0;
+const MIN_HEIGHT = 5;
 const MAX_HEIGHT = 1000;
 
 const Edit = ( { attributes, isSelected, setAttributes } ) => {


### PR DESCRIPTION
It doesn't make sense to have 0 px block