### PR TITLE
Sketch block: Remove unnecessary className when calling useBlockProps

### DIFF
--- a/blocks/sketch/src/edit.js
+++ b/blocks/sketch/src/edit.js
@@ -27,7 +27,6 @@ const Edit = ( { attributes, isSelected, setAttributes } ) => {
 	const [ color, setColor ] = useState( '#000' );
 	const ref = useRef( null );
 	const blockProps = useBlockProps( {
-		className: 'wp-block-a8c-sketch',
 		ref,
 	} );
 	const handlePointerDown = useCallback( ( e ) => {


### PR DESCRIPTION
The className is already added by userBlockProps() there and gets to be duplicated if we add its key here