### PR TITLE
Sketch block: Add default and custom color palettes

### DIFF
--- a/blocks/sketch/editor.scss
+++ b/blocks/sketch/editor.scss
@@ -7,4 +7,12 @@
 			min-width: initial;
 		}
 	}
+	&__color-palette-popover {
+		/**
+		 * Take care of default width for popover content.
+		 */
+		.components-popover__content {
+			padding: 16px;
+		}
+	}
 }

--- a/blocks/sketch/src/controls.js
+++ b/blocks/sketch/src/controls.js
@@ -148,7 +148,7 @@ const Controls = ( {
 						<ColorPalette
 							clearable={ false }
 							colors={ colors }
-							color={ color }
+							value={ color }
 							disableCustomColors={ true }
 							headingLevel="2"
 							onChange={ setColor }

--- a/blocks/sketch/src/controls.js
+++ b/blocks/sketch/src/controls.js
@@ -54,7 +54,15 @@ const Controls = ( {
 	blockRef,
 	attributes,
 } ) => {
-	const colors = useSetting( 'color.palette' ) || [];
+	const themePalette = useSetting( 'color.palette.theme' ) || [];
+	const defaultPalette = useSetting( 'color.palette.default' ) || [];
+	const userPalette = useSetting( 'color.palette.custom' ) || [];
+
+	const colors = [
+		themePalette.length ? { name: __( 'Theme', 'a8c-sketch' ), colors: themePalette } : null,
+		defaultPalette.length ? { name: __( 'Default', 'a8c-sketch' ), colors: defaultPalette } : null,
+		userPalette.length ? { name: __( 'Custom', 'a8c-sketch' ), colors: userPalette } : null,
+	].filter( Boolean );
 	const { createErrorNotice, createInfoNotice } = useDispatch( noticesStore );
 	function getSVGNodeElement() {
 		if ( ! blockRef.current ) {
@@ -139,6 +147,7 @@ const Controls = ( {
 							colors={ colors }
 							color={ color }
 							disableCustomColors={ true }
+							headingLevel="2"
 							onChange={ setColor }
 						/>
 					) }

--- a/blocks/sketch/src/controls.js
+++ b/blocks/sketch/src/controls.js
@@ -135,7 +135,10 @@ const Controls = ( {
 				/>
 				<ToolbarDropdownMenu
 					isCollapsed
-					popoverProps={ { variant: 'toolbar' } }
+					popoverProps={ {
+						className: 'wp-block-a8c-sketch__color-palette-popover',
+						variant: 'toolbar'
+					} }
 					icon={
 						<Icon icon={ <ColorControlIcon color={ color } /> } />
 					}

--- a/blocks/sketch/src/controls.js
+++ b/blocks/sketch/src/controls.js
@@ -135,7 +135,7 @@ const Controls = ( {
 				/>
 				<ToolbarDropdownMenu
 					isCollapsed
-					popoverProps={ { isAlternate: true } }
+					popoverProps={ { variant: 'toolbar' } }
 					icon={
 						<Icon icon={ <ColorControlIcon color={ color } /> } />
 					}


### PR DESCRIPTION
<table>
<tr>
	<td>
<img width="586" alt="image" src="https://user-images.githubusercontent.com/746152/222794805-ed72e738-0190-44a3-90a5-aa8af7bf7599.png">
	<td><img width="714" alt="image" src="https://user-images.githubusercontent.com/746152/222794558-4d3d5497-a717-4309-b6bc-a90d66413260.png">
</td>
</tr>
<tr>
	<td>Before
	<td>After
</table>

* Adds default and custom color palettes
* Fixes warning about deprecated isAlternate prop on Popover component 
* Adds padding to color palette popover
* Fixes selected value prop name passed to ColorPalette