### PR TITLE
Sketch Block: Add prop __experimentalHasMultipleOrigins to ColorPalette use to support WordPress 6.1.1

### DIFF
--- a/blocks/sketch/src/controls.js
+++ b/blocks/sketch/src/controls.js
@@ -152,6 +152,7 @@ const Controls = ( {
 							disableCustomColors={ true }
 							headingLevel="2"
 							onChange={ setColor }
+							__experimentalHasMultipleOrigins={ true }
 						/>
 					) }
 				</ToolbarDropdownMenu>


### PR DESCRIPTION
Seems like before Gutenberg 15.2.3, `__experimentalHasMultipleOrigins` was needed.


See https://github.com/Automattic/block-experiments/pull/319#issuecomment-1454336480