### PR TITLE
Layout Grid: Don't write back to `props` in icon

### DIFF
--- a/blocks/layout-grid/src/icons.js
+++ b/blocks/layout-grid/src/icons.js
@@ -5,16 +5,17 @@
 import { Path, SVG } from '@wordpress/components';
 
 export const GridIcon = ( props ) => {
+	const iconProps = {...props};
 	if ( props.size ) {
-		props.width = props.size;
-		props.height = props.size;
+		iconProps.width = props.size;
+		iconProps.height = props.size;
 	}
 
 	return (
 		<SVG xmlns="http://www.w3.org/2000/svg"
 			width="24" height="24"
 			viewBox="0 0 24 24"
-			{ ...props }
+			{ ...iconProps }
 		>
 			<Path d="M19 6H6c-1.1 0-2 .9-2 2v9c0 1.1.9 2 2 2h13c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-7.5 11.5H6c-.3 0-.5-.2-.5-.5V8c0-.3.2-.5.5-.5h5.5v10zm4 0H13v-10h2.5v10zm4-.5c0 .3-.2.5-.5.5h-2v-10h2c.3 0 .5.2.5.5v9z" />
 		</SVG>

--- a/blocks/layout-grid/src/icons.js
+++ b/blocks/layout-grid/src/icons.js
@@ -5,7 +5,7 @@
 import { Path, SVG } from '@wordpress/components';
 
 export const GridIcon = ( props ) => {
-	const iconProps = {...props};
+	const iconProps = { ...props };
 	if ( props.size ) {
 		iconProps.width = props.size;
 		iconProps.height = props.size;


### PR DESCRIPTION
Writing to the `props` passed causes an error if it doesn't already have width and height properties as the object isn't extensible.

This is fixed by copying to an intermediary object and then using that.

This error is fatal - crashes the whole of GB when using current GB trunk (15d644f2)

### Testing steps
 1. Checkout this branch locally
 2. `nvm use && yarn install`
 3. Build these changes: `yarn plugin layout-grid && yarn bundle`
 4. Get the built plugin in your test environment
    1. For wpcom unzip the plugin: `cd bundles && unzip jetpack-layout-grid.zip && cd jetpack-layout-grid`
    2. Then copy it up`scp -r * wpcom-sandbox:public_html/wp-content/plugins/gutenberg-blocks/jetpack-layout-grid/`
 5. Make your test environment use the latest version of GB, for wpcom see the FGs gutenberg-plugin-on-wpcom

Closes #328 