### PR TITLE
Add the .idea folder to the .gitingnore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 /bundles
 /vendor
 /dist
+/.idea
 yarn-error.log
 .DS_Store


### PR DESCRIPTION
This PR excludes the `.idea` folder by adding it to the `.gitignore` file so that we don't accidentally add PHPStorm's settings to the project.