### PR TITLE
Motion Background: Fix function redeclaration error

### DIFF
--- a/blocks/motion-background/index.php
+++ b/blocks/motion-background/index.php
@@ -1,39 +1,52 @@
 <?php
 
-add_action( 'init', function() {
-	register_block_type( 'a8c/motion-background', [
+namespace Automattic\A8c\Plugins\Blocks\MotionBackground;
+
+const FEATURE_NAME = 'motion-background';
+const BLOCK_NAME   = 'a8c/' . FEATURE_NAME;
+
+/**
+ * Registers the block for use in Gutenberg
+ * This is done via an action so that we can disable
+ * registration if we need to.
+ */
+function register_block() {
+	register_block_type( BLOCK_NAME, [
 		'editor_script' => 'block-experiments',
 		'style' => 'block-experiments',
 		'editor_style' => 'block-experiments-editor',
+		'render_callback' => __NAMESPACE__ . '\load_assets',
 	] );
-} );
+}
+add_action( 'init', __NAMESPACE__ . '\register_block' );
 
-add_action( 'enqueue_block_assets', function() {
-	// https://github.com/WordPress/gutenberg/issues/14758#issuecomment-478912504
-	function some_posts_have_block( $block_type ) {
-		global $wp_the_query;
-		foreach ( $wp_the_query->posts as $post ) {
-			if ( has_block( $block_type, $post ) ) {
-				return TRUE;
-			}
-		}
-		return FALSE;
+/**
+ * Motion Background block registration/dependency declaration.
+ *
+ * @param array  $attr    Array containing the Motion Background block attributes.
+ * @param string $content String containing the Motion Background block content.
+ *
+ * @return string
+ */
+function load_assets( $attr, $content ) {
+	if ( is_admin() ) {
+		return $content;
 	}
 
-	if ( ! is_admin() && some_posts_have_block( 'a8c/motion-background' ) ) {
-		wp_enqueue_script(
-			'wpcom-twgl-js',
-			plugins_url( 'twgl/twgl.js', __FILE__ ),
-			[], // no dependencies
-			filemtime( plugin_dir_path( __FILE__ ) . 'twgl/twgl.js' ),
-			true // in footer
-		);
-		wp_enqueue_script(
-			'wpcom-motion-background-js',
-			plugins_url( 'motion-background.js', __FILE__ ),
-			[ 'wpcom-twgl-js', 'lodash' ],
-			filemtime( plugin_dir_path( __FILE__ ) . 'motion-background.js' ),
-			true // in footer
-		);
-	}
-} );
+	wp_enqueue_script(
+		'a8c-twgl-js',
+		plugins_url( 'twgl/twgl.js', __FILE__ ),
+		[], // no dependencies
+		filemtime( plugin_dir_path( __FILE__ ) . 'twgl/twgl.js' ),
+		true // in footer
+	);
+	wp_enqueue_script(
+		'a8c-' . FEATURE_NAME . '-js',
+		plugins_url( 'motion-background.js', __FILE__ ),
+		[ 'wpcom-twgl-js', 'lodash' ],
+		filemtime( plugin_dir_path( __FILE__ ) . 'motion-background.js' ),
+		true // in footer
+	);
+
+	return $content;
+}


### PR DESCRIPTION
## Description

In WordPress 6.3, the `enqueue_block_assets` was getting called twice causing the function inside to be redeclared.

This PR fixes the issue by moving the script enqueues into the `render_callback`. The code is also refactored to be a bit more like how [Jetpack blocks](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/extensions/blocks/calendly/calendly.php) are structured.

## Testing Instructions

1. Open the site editor and post editor.
2. See that there are no errors.
