### PR TITLE
Mobile - Layout Grid block - Update placeholder styles

### DIFF
--- a/blocks/layout-grid/src/grid-column/edit.native.scss
+++ b/blocks/layout-grid/src/grid-column/edit.native.scss
@@ -1,18 +1,17 @@
 .column__placeholder {
 	flex: 1;
 	padding: $block-selected-to-content;
-	background-color: $white;
 	border: $border-width dashed $gray;
 	border-radius: 4px;
 }
 
 .column__placeholder-dark {	
-	background-color: $black;
 	border: $border-width dashed $gray-70;
 }
 
 .column__placeholder-not-selected {
-	padding-top: $block-selected-to-content;
+	padding: $block-selected-to-content;
+	border: $border-width dashed $gray;
 }
 
 .column__appender {


### PR DESCRIPTION
This PR updates the placeholder for the Layout Grid block on mobile.

It also removes the solid backgrounds in the placeholders, this was causing visual issues for block-based themes with custom background colors.

After
-|
<video src="https://github.com/Automattic/block-experiments/assets/4885740/6b8d6d89-6a2a-466c-b778-1e626de6388e" width=200 />|

