### PR TITLE
Event Block: Update deprecated APIs

### DIFF
--- a/blocks/event/src/date-select.js
+++ b/blocks/event/src/date-select.js
@@ -13,7 +13,9 @@ const DateSelect = ( {
 } ) => (
 	<Dropdown
 		className={ className }
-		position="bottom left"
+		popoverProps={ {
+			placement: 'bottom-start',
+		} }
 		renderToggle={ ( { onToggle, isOpen } ) => (
 			<Button
 				className="button"

--- a/blocks/event/src/edit.js
+++ b/blocks/event/src/edit.js
@@ -24,7 +24,7 @@ import {
 	Button,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { __experimentalGetSettings, dateI18n } from '@wordpress/date';
+import { getSettings, dateI18n } from '@wordpress/date';
 
 /**
  * Internal dependencies
@@ -43,7 +43,7 @@ const Edit = ( {
 	setBackgroundColor,
 	isSelected,
 } ) => {
-	const settings = __experimentalGetSettings();
+	const settings = getSettings();
 
 	const classNames = [ textColor.class, backgroundColor.class ];
 	const style = {
@@ -152,7 +152,6 @@ const Edit = ( {
 						tagName="h3"
 						className="event__title"
 						value={ attributes.eventTitle }
-						keepPlaceholderOnFocus
 						onChange={ ( eventTitle ) =>
 							setAttributes( { eventTitle } )
 						}
@@ -190,8 +189,6 @@ const Edit = ( {
 						</span>
 						<RichText
 							value={ attributes.eventLocation }
-							multiline="false"
-							keepPlaceholderOnFocus
 							onChange={ ( eventLocation ) =>
 								setAttributes( { eventLocation } )
 							}

--- a/blocks/event/src/save.js
+++ b/blocks/event/src/save.js
@@ -11,7 +11,7 @@ import {
 	RichText,
 	getColorClassName,
 } from '@wordpress/block-editor';
-import { __experimentalGetSettings, dateI18n } from '@wordpress/date';
+import { getSettings, dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -20,7 +20,7 @@ import { __ } from '@wordpress/i18n';
 import DateSelect from './date-select';
 
 const Save = ( { attributes } ) => {
-	const settings = __experimentalGetSettings();
+	const settings = getSettings();
 
 	const classNames = [
 		getColorClassName( 'color', attributes.textColor ),

--- a/bundler/resources/a8c-event/readme.txt
+++ b/bundler/resources/a8c-event/readme.txt
@@ -15,9 +15,9 @@ Let everyone know about the events going on. Whether you're hosting or attending
 
 ## Source and Support
 
-This block is in maintenance mode and will not be receiving new features.
+This block is no longer under active development and will not be receiving new features.
 
-Issues can be reported and the full source is available at the Github repo: <a href="https://github.com/Automattic/block-experiments">https://github.com/Automattic/block-experiments</a>
+Full source is available at the Github repo: <a href="https://github.com/Automattic/block-experiments">https://github.com/Automattic/block-experiments</a>
 
 == Screenshots ==
 

--- a/bundler/resources/a8c-event/readme.txt
+++ b/bundler/resources/a8c-event/readme.txt
@@ -26,6 +26,10 @@ Full source is available at the Github repo: <a href="https://github.com/Automat
 
 == Changelog ==
 
+= 1.0.3 - 23nd October 2023 =
+* Update to use stabilized APIs.
+* Fix console warnings in the editor.
+
 = 1.0.2 - 22nd July 2021 =
 * Improve compatibility with block directory
 * Fix center aligned styling

--- a/bundler/resources/a8c-event/readme.txt
+++ b/bundler/resources/a8c-event/readme.txt
@@ -1,7 +1,7 @@
 === Event Block ===
 Contributors: automattic, ajlende, jasmussen
 Stable tag: 1.0.2
-Tested up to: 6.0
+Tested up to: 6.4
 Requires at least: 5.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -15,7 +15,9 @@ Let everyone know about the events going on. Whether you're hosting or attending
 
 ## Source and Support
 
-You can follow development, file an issue, suggest features, and view the source at the Github repo: <a href="https://github.com/Automattic/block-experiments">https://github.com/Automattic/block-experiments</a>
+This block is in maintenance mode and will not be receiving new features.
+
+Issues can be reported and the full source is available at the Github repo: <a href="https://github.com/Automattic/block-experiments">https://github.com/Automattic/block-experiments</a>
 
 == Screenshots ==
 

--- a/bundler/resources/a8c-event/readme.txt
+++ b/bundler/resources/a8c-event/readme.txt
@@ -15,7 +15,7 @@ Let everyone know about the events going on. Whether you're hosting or attending
 
 ## Source and Support
 
-This block is no longer under active development and will not be receiving new features.
+This block is no longer under active development. Bug reports will be fixed, but no new features will be added.
 
 Full source is available at the Github repo: <a href="https://github.com/Automattic/block-experiments">https://github.com/Automattic/block-experiments</a>
 

--- a/bundler/resources/a8c-event/readme.txt
+++ b/bundler/resources/a8c-event/readme.txt
@@ -1,6 +1,6 @@
 === Event Block ===
 Contributors: automattic, ajlende, jasmussen
-Stable tag: 1.0.2
+Stable tag: 1.0.3
 Tested up to: 6.4
 Requires at least: 5.4
 License: GPLv2 or later

--- a/bundler/resources/a8c-event/readme.txt
+++ b/bundler/resources/a8c-event/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, ajlende, jasmussen
 Stable tag: 1.0.3
 Tested up to: 6.4
-Requires at least: 5.4
+Requires at least: 6.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Tags: block, event, card


### PR DESCRIPTION
Some of the experimental APIs used when this block was created were stabilized or removed in later versions of Gutenberg, so they have been replaced or removed to work with WordPress 6.4.

Also added a note about this block no longer being actively developed.