### PR TITLE
Fix grid resize listeners

### DIFF
--- a/blocks/layout-grid/src/grid/resize-grid/index.js
+++ b/blocks/layout-grid/src/grid/resize-grid/index.js
@@ -41,7 +41,18 @@ class ResizeGrid extends Component {
 		const { totalColumns, layoutGrid } = this.props;
 		const start = layoutGrid.getStart( this.state.resizingColumn );
 		const span = layoutGrid.getSpan( this.state.resizingColumn );
-		const nearest = Math.min( totalColumns, Math.max( 0, findNearest( this.containerRef.current, this.getMouseX( mouse ), direction, totalColumns ) ) );
+		const nearest = Math.min(
+			totalColumns,
+			Math.max(
+				0,
+				findNearest(
+					this.containerRef.current,
+					this.getMouseX( mouse ),
+					direction,
+					totalColumns
+				)
+			)
+		);
 
 		if ( direction === 'left' ) {
 			if ( nearest === start ) {
@@ -85,7 +96,11 @@ class ResizeGrid extends Component {
 		const { width } = this.state;
 		const handleWidth = optionalWidth > 0 ? optionalWidth : width;
 
-		return offset - this.containerRef.current.getBoundingClientRect().left - ( ( handleWidth ) / 2 );
+		return (
+			offset -
+			this.containerRef.current.getBoundingClientRect().left -
+			handleWidth / 2
+		);
 	}
 
 	getAdjustedTop( offset ) {
@@ -114,15 +129,19 @@ class ResizeGrid extends Component {
 		return pos;
 	}
 
-	onMouseDown = ev => {
+	onMouseDown = ( ev ) => {
 		const { target } = ev;
 
 		// This is a bit of hardcoded DOM searching - we check if the current click is on a resize handle and then find the column associated with that
 		// There may be a better way.
-		if ( ( ev.button === 0 || ev.touches ) && ( target.dataset.resizeRight || target.dataset.resizeLeft ) ) {
+		if (
+			( ev.button === 0 || ev.touches ) &&
+			( target.dataset.resizeRight || target.dataset.resizeLeft )
+		) {
 			this.block = target.closest( '.wp-block' );
 
-			const { height, right, left, top } = this.block.getBoundingClientRect();
+			const { height, right, left, top } =
+				this.block.getBoundingClientRect();
 			const { width } = target.getBoundingClientRect();
 			const pos = this.getChildPosition( this.block );
 			const isLeft = target.dataset.resizeLeft;
@@ -134,7 +153,9 @@ class ResizeGrid extends Component {
 				width,
 				top: this.getAdjustedTop( top ),
 				direction: isLeft ? 'left' : 'right',
-				max: isLeft ? this.getAdjustedOffset( right, width ) : this.getAdjustedOffset( left, width ),
+				max: isLeft
+					? this.getAdjustedOffset( right, width )
+					: this.getAdjustedOffset( left, width ),
 			} );
 
 			if ( ev.button === 0 ) {
@@ -149,9 +170,9 @@ class ResizeGrid extends Component {
 
 			ev.stopPropagation();
 		}
-	}
+	};
 
-	onMouseMove = ev => {
+	onMouseMove = ( ev ) => {
 		ev.stopPropagation();
 
 		if ( ev.touches === undefined ) {
@@ -161,7 +182,9 @@ class ResizeGrid extends Component {
 		const { height } = this.block.getBoundingClientRect();
 
 		this.setState( {
-			xPos: this.getRestrictedOffset( this.getAdjustedOffset( this.getMouseX( ev ) ) ),
+			xPos: this.getRestrictedOffset(
+				this.getAdjustedOffset( this.getMouseX( ev ) )
+			),
 			height,
 		} );
 
@@ -170,28 +193,43 @@ class ResizeGrid extends Component {
 		if ( adjustment ) {
 			this.props.onResize( this.state.resizingColumn, adjustment );
 		}
-	}
+	};
 
-	onMouseUp = ev => {
+	onMouseUp = ( ev ) => {
 		this.setState( { resizingColumn: -1 } );
 
 		document.removeEventListener( 'mousemove', this.onMouseMove );
 		document.removeEventListener( 'mouseup', this.onMouseUp );
 		document.removeEventListener( 'touchmove', this.onMouseMove );
 		document.removeEventListener( 'touchend', this.onMouseUp );
-	}
+	};
 
 	render() {
 		const { className, children, isSelected } = this.props;
 		const { resizingColumn, xPos, height } = this.state;
 		const classes = classnames(
 			className,
-			resizingColumn !== -1 ? 'wp-block-jetpack-layout-grid__resizing' : null,
+			resizingColumn !== -1
+				? 'wp-block-jetpack-layout-grid__resizing'
+				: null
 		);
 
 		return (
-			<div className={ classes } onMouseDown={ this.onMouseDown } onTouchStart={ this.onMouseDown } ref={ this.containerRef }>
-				{ resizingColumn !== -1 && <ResizeHandle direction={ this.state.direction } height={ height } xPos={ xPos } top={ this.state.top } isSelected={ isSelected } /> }
+			<div
+				className={ classes }
+				onMouseDown={ this.onMouseDown }
+				onTouchStart={ this.onMouseDown }
+				ref={ this.containerRef }
+			>
+				{ resizingColumn !== -1 && (
+					<ResizeHandle
+						direction={ this.state.direction }
+						height={ height }
+						xPos={ xPos }
+						top={ this.state.top }
+						isSelected={ isSelected }
+					/>
+				) }
 				{ children }
 			</div>
 		);

--- a/blocks/layout-grid/src/grid/resize-grid/index.js
+++ b/blocks/layout-grid/src/grid/resize-grid/index.js
@@ -219,6 +219,8 @@ class ResizeGrid extends Component {
 				className={ classes }
 				onMouseDown={ this.onMouseDown }
 				onTouchStart={ this.onMouseDown }
+				onMouseUp={ this.onMouseUp }
+				onTouchEnd={ this.onMouseUp }
 				ref={ this.containerRef }
 			>
 				{ resizingColumn !== -1 && (

--- a/blocks/layout-grid/src/grid/resize-grid/index.js
+++ b/blocks/layout-grid/src/grid/resize-grid/index.js
@@ -160,12 +160,9 @@ class ResizeGrid extends Component {
 
 			if ( ev.button === 0 ) {
 				document.addEventListener( 'mousemove', this.onMouseMove );
-				document.addEventListener( 'mouseup', this.onMouseUp );
-
 				ev.preventDefault();
 			} else {
 				document.addEventListener( 'touchmove', this.onMouseMove );
-				document.addEventListener( 'touchend', this.onMouseUp );
 			}
 
 			ev.stopPropagation();
@@ -196,12 +193,13 @@ class ResizeGrid extends Component {
 	};
 
 	onMouseUp = ( ev ) => {
-		this.setState( { resizingColumn: -1 } );
+		if ( this.state.resizingColumn === -1 ) {
+			return;
+		}
 
+		this.setState( { resizingColumn: -1 } );
 		document.removeEventListener( 'mousemove', this.onMouseMove );
-		document.removeEventListener( 'mouseup', this.onMouseUp );
 		document.removeEventListener( 'touchmove', this.onMouseMove );
-		document.removeEventListener( 'touchend', this.onMouseUp );
 	};
 
 	render() {

--- a/blocks/layout-grid/src/grid/resize-grid/index.js
+++ b/blocks/layout-grid/src/grid/resize-grid/index.js
@@ -140,6 +140,11 @@ class ResizeGrid extends Component {
 		) {
 			this.block = target.closest( '.wp-block' );
 
+			// Get the document that contains the target element. We need to use target.ownerDocument
+			// because the Gutenberg editor is iframed, so some events are prevented from bubbling to the document.
+			// https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/iframe/index.js#L79
+			this.targetDocument = target.ownerDocument;
+
 			const { height, right, left, top } =
 				this.block.getBoundingClientRect();
 			const { width } = target.getBoundingClientRect();
@@ -159,12 +164,25 @@ class ResizeGrid extends Component {
 			} );
 
 			if ( ev.button === 0 ) {
-				document.addEventListener( 'mousemove', this.onMouseMove );
-				document.addEventListener( 'mouseup', this.onMouseUp );
+				// Add listeners to the target document instead of global document
+				this.targetDocument.addEventListener(
+					'mousemove',
+					this.onMouseMove
+				);
+				this.targetDocument.addEventListener(
+					'mouseup',
+					this.onMouseUp
+				);
 				ev.preventDefault();
 			} else {
-				document.addEventListener( 'touchmove', this.onMouseMove );
-				document.addEventListener( 'touchend', this.onMouseUp );
+				this.targetDocument.addEventListener(
+					'touchmove',
+					this.onMouseMove
+				);
+				this.targetDocument.addEventListener(
+					'touchend',
+					this.onMouseUp
+				);
 			}
 
 			ev.stopPropagation();
@@ -200,8 +218,14 @@ class ResizeGrid extends Component {
 		}
 
 		this.setState( { resizingColumn: -1 } );
-		document.removeEventListener( 'mousemove', this.onMouseMove );
-		document.removeEventListener( 'touchmove', this.onMouseMove );
+		this.targetDocument.removeEventListener(
+			'mousemove',
+			this.onMouseMove
+		);
+		this.targetDocument.removeEventListener(
+			'touchmove',
+			this.onMouseMove
+		);
 	};
 
 	render() {
@@ -219,8 +243,6 @@ class ResizeGrid extends Component {
 				className={ classes }
 				onMouseDown={ this.onMouseDown }
 				onTouchStart={ this.onMouseDown }
-				onMouseUp={ this.onMouseUp }
-				onTouchEnd={ this.onMouseUp }
 				ref={ this.containerRef }
 			>
 				{ resizingColumn !== -1 && (

--- a/blocks/layout-grid/src/grid/resize-grid/index.js
+++ b/blocks/layout-grid/src/grid/resize-grid/index.js
@@ -160,9 +160,11 @@ class ResizeGrid extends Component {
 
 			if ( ev.button === 0 ) {
 				document.addEventListener( 'mousemove', this.onMouseMove );
+				document.addEventListener( 'mouseup', this.onMouseUp );
 				ev.preventDefault();
 			} else {
 				document.addEventListener( 'touchmove', this.onMouseMove );
+				document.addEventListener( 'touchend', this.onMouseUp );
 			}
 
 			ev.stopPropagation();


### PR DESCRIPTION
Fixes https://github.com/Automattic/block-experiments/issues/327

The ResizeGrid component was not emitting the onMouseUp event. Attaching it to the div allows the mouseUp to be emitted if you're within the block. This is not a full fix though. The mouseUp event should be emitted anywhere you release it, not just within the block.

Maybe it would be worth updating this to the [Resizeable box component](https://wordpress.github.io/gutenberg/?path=/docs/components-resizablebox--docs) and only enable the left/right handles. 

**Before**

https://github.com/user-attachments/assets/021bb02a-6291-4e0d-9429-aaad1d00ce98

**After**

https://github.com/user-attachments/assets/d55707c7-38bc-4dac-9e0b-c5a227243f25

